### PR TITLE
[REFACTOR(#12)] 카카오 소셜 로그인 절차 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	// postgresql
-	implementation 'org.postgresql:postgresql:42.7.2'
+	implementation 'org.postgresql:postgresql:42.7.5'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ dependencies {
 	// webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	// postgresql
+	implementation 'org.postgresql:postgresql:42.7.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/prography/minari/common/execption/ApiException.java
+++ b/src/main/java/com/prography/minari/common/execption/ApiException.java
@@ -1,0 +1,16 @@
+package com.prography.minari.common.execption;
+
+public class ApiException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+    public ApiException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+}

--- a/src/main/java/com/prography/minari/common/execption/ErrorCode.java
+++ b/src/main/java/com/prography/minari/common/execption/ErrorCode.java
@@ -1,0 +1,25 @@
+package com.prography.minari.common.execption;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력입니다."),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "데이터를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/prography/minari/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/prography/minari/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.prography.minari.common.handler;
+
+import com.prography.minari.common.execption.ApiException;
+import com.prography.minari.common.response.ApiResponse;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApiException.class)
+    public ApiResponse handleApiException(ApiException e) {
+        return ApiResponse.fail();
+    }
+
+}

--- a/src/main/java/com/prography/minari/common/response/ApiResponse.java
+++ b/src/main/java/com/prography/minari/common/response/ApiResponse.java
@@ -1,0 +1,40 @@
+package com.prography.minari.common.response;
+
+import lombok.Data;
+
+@Data
+public class ApiResponse<T> {
+    private Integer code;
+    private String message;
+    private T result;
+
+    public static <T> ApiResponse<T> success(T result) {
+        return new ApiResponse<>(200, "API 요청이 성공했습니다.", result);
+    }
+
+    public static ApiResponse<Void> success() {
+        return success(null);
+    }
+
+    public static <T> ApiResponse<T> fail(T result) {
+        return new ApiResponse<>(201, "불가능한 요청입니다.", result);
+    }
+
+    public static ApiResponse<Void> fail() {
+        return fail(null);
+    }
+
+    public static <T> ApiResponse<T> error(T result) {
+        return new ApiResponse<>(500, "에러가 발생했습니다.", result);
+    }
+
+    public static ApiResponse<Void> error() {
+        return error(null);
+    }
+
+    private ApiResponse(Integer code, String message, T result) {
+        this.code = code;
+        this.message = message;
+        this.result = result;
+    }
+}

--- a/src/main/java/com/prography/minari/social/service/KakaoSocialServiceImpl.java
+++ b/src/main/java/com/prography/minari/social/service/KakaoSocialServiceImpl.java
@@ -8,6 +8,8 @@ import com.prography.minari.user.entity.User;
 import com.prography.minari.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -59,7 +61,7 @@ public class KakaoSocialServiceImpl implements SocialService {
                 .baseUrl("https://kauth.kakao.com").build()
                 .post()
                 .uri("/oauth/token")
-                .header("Content-Type", "application/x-www-form-urlencoded")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                 .body(BodyInserters.fromFormData("grant_type", "authorization_code")
                         .with("client_id", CLIENT_ID)
                         .with("redirect_uri", REDIRECT_URI)
@@ -77,8 +79,8 @@ public class KakaoSocialServiceImpl implements SocialService {
                 .build()
                 .get()
                 .uri("/v1/user/access_token_info")
-                .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
-                .header("Authorization", "Bearer " + accessToken)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                 .retrieve()
                 .bodyToMono(KakaoTokenInfoResDto.class)
                 .block();
@@ -95,8 +97,8 @@ public class KakaoSocialServiceImpl implements SocialService {
                         .queryParam("target_id_type", "user_id")
                         .queryParam("target_id", userId)
                         .build())
-                .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
-                .header("Authorization", "Bearer " + accessToken)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                 .body(BodyInserters.fromFormData("property_keys", "[\"kakao_account.profile\"]"))
                 .retrieve()
                 .bodyToMono(KakaoUserInfoResDto.class)

--- a/src/main/java/com/prography/minari/social/service/KakaoSocialServiceImpl.java
+++ b/src/main/java/com/prography/minari/social/service/KakaoSocialServiceImpl.java
@@ -50,7 +50,7 @@ public class KakaoSocialServiceImpl implements SocialService {
 
         // 사용자 정보로 기존 회원 조회, 없으면 새 User 객체 생성
         User user = userRepository.findBySocialTypeAndSocialId(KAKAO, socialId)
-                .orElseGet(() -> userRepository.save(User.create("", KAKAO, socialId, image, name)));
+                .orElseGet(() -> userRepository.save(User.create("", KAKAO, socialId, name, image)));
 
         return UserLoginResDto.from(user);
     }

--- a/src/main/java/com/prography/minari/user/controller/UserController.java
+++ b/src/main/java/com/prography/minari/user/controller/UserController.java
@@ -27,17 +27,7 @@ public class UserController {
 
     @GetMapping("/users/oauth/{social}")
     public ResponseEntity oauth(@RequestParam("code")String code, @PathVariable("social") String social) {
-
         UserLoginResDto userLoginResDto = socialServiceMap.get(social).login(code);
-
-        // 신규 회원일 경우, 회원 등록 절차를 위한 redirect
-        if(userLoginResDto.isNotRegistered()) {
-            return ResponseEntity
-                    .status(HttpStatus.FOUND)
-                    .location(URI.create("/")) // 리다이렉트할 경로
-                    .build();
-        }
-
         return ResponseEntity.ok(userLoginResDto);
     }
 

--- a/src/main/java/com/prography/minari/user/controller/UserController.java
+++ b/src/main/java/com/prography/minari/user/controller/UserController.java
@@ -8,10 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.Map;
@@ -20,6 +17,7 @@ import static org.springframework.http.HttpStatus.FOUND;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1")
 public class UserController {
 
     private final UserService userService;

--- a/src/main/java/com/prography/minari/user/dto/UserLoginResDto.java
+++ b/src/main/java/com/prography/minari/user/dto/UserLoginResDto.java
@@ -5,7 +5,7 @@ import com.prography.minari.user.entity.User;
 import io.micrometer.common.util.StringUtils;
 
 public record UserLoginResDto(
-        Long id, String email, SocialType socialType, String socialId, String name, String image)
+        Long id, String email, SocialType socialType, String socialId, String name, String image, Boolean registered)
 {
     public static UserLoginResDto from(User user) {
         return new UserLoginResDto(
@@ -14,11 +14,9 @@ public record UserLoginResDto(
                 user.getSocialType(),
                 String.valueOf(user.getSocialId()), // socialId가 String이면 그대로, Long이면 변환
                 user.getName(),
-                user.getImage()
+                user.getImage(),
+                user.getRegistered()
         );
     }
 
-    public boolean isNotRegistered() {
-        return StringUtils.isEmpty(email);
-    }
 }

--- a/src/main/java/com/prography/minari/user/entity/User.java
+++ b/src/main/java/com/prography/minari/user/entity/User.java
@@ -40,6 +40,7 @@ public class User extends BaseTimeEntity {
         user.socialId = socialId;
         user.name = name;
         user.image = image;
+        user.registered = false;
         return user;
     }
 

--- a/src/main/java/com/prography/minari/user/entity/User.java
+++ b/src/main/java/com/prography/minari/user/entity/User.java
@@ -31,6 +31,8 @@ public class User extends BaseTimeEntity {
 
     private String image;
 
+    private Boolean registered;
+
     public static User create(String email, SocialType socialType, Long socialId, String name, String image) {
         User user = new User();
         user.email = email;


### PR DESCRIPTION
## #️⃣연관된 이슈

#12 

## 📝작업 내용

소셜 로그인 절차를 변경한다.

### AS-IS
- 기존 계정 : 그대로 응답값을 반환
- 새로운 계정 : '/' 페이지로 redirection
- 
### TO-BE

- 해당 회원의 구분을 명확히 하고, 일관된 응답값을 반환한다.

**[미나리 페이지에서 회원가입 절차 완료한 회원]**
```
{
    "code": 1,
    "user" : {
        "id": 1,
        "email": "user@example.com",
        "socialType": "KAKAO",
        "socialId": "1234567890",
        "name": "김태식",
        "image": "https://example.com/profile.jpg",
        "registered": true
    }
}
```

**[미나리 페이지에서 회원가입 절차 완료하지 않은 회원]**
```
{
    "code": 2,
    "user" : {
        "id": 1,
        "email": "{있을 수도 없을 수도}",
        "socialType": "KAKAO",
        "socialId": "1234567890",
        "name": "김태식",
        "image": "https://example.com/profile.jpg",
        "registered": false
    }
}
```

### 🛠 Features
- USERS 테이블에 해당 계정이 회원가입 절차를 진행했는지 식별할 수 있는 registered 필드 추가
- registered 값을 UserLoginResDto에 추가

![image](https://github.com/user-attachments/assets/9efe66c2-8110-405e-94a7-47abba240ffd)

- 서버에서 name과 image를 반대로 저장하고 있는 것을 확인.
- registered 값 boolean 타입으로 반환할 수 있도록 수정
- 지원님이 QA해주셨다..
