### PR TITLE
[FEAT(#20)] JWT 발급 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,11 @@ dependencies {
 	// postgresql
 	implementation 'org.postgresql:postgresql:42.7.5'
 
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // Jackson 기반 파싱
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/prography/minari/common/execption/ApiException.java
+++ b/src/main/java/com/prography/minari/common/execption/ApiException.java
@@ -2,15 +2,15 @@ package com.prography.minari.common.execption;
 
 public class ApiException extends RuntimeException{
 
-    private final ErrorCode errorCode;
+    private final String code;
 
-    public ApiException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+    public ApiException(String code) {
+        super();
+        this.code = code;
     }
 
-    public ErrorCode getErrorCode() {
-        return errorCode;
+    public String getErrorCode() {
+        return code;
     }
 
 }

--- a/src/main/java/com/prography/minari/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/prography/minari/common/handler/GlobalExceptionHandler.java
@@ -2,8 +2,15 @@ package com.prography.minari.common.handler;
 
 import com.prography.minari.common.execption.ApiException;
 import com.prography.minari.common.response.ApiResponse;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.security.SignatureException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -11,6 +18,30 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ApiException.class)
     public ApiResponse handleApiException(ApiException e) {
         return ApiResponse.fail();
+    }
+
+    @ExceptionHandler(ExpiredJwtException.class)
+    public ResponseEntity handleExpiredJwtException(ExpiredJwtException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body("토큰이 만료되었습니다.");
+    }
+
+    @ExceptionHandler(SignatureException.class)
+    public ResponseEntity handleSignatureException(SignatureException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body("유효하지 않은 서명입니다.");
+    }
+
+    @ExceptionHandler(UnsupportedJwtException.class)
+    public ResponseEntity handleUnsupportedJwtException(UnsupportedJwtException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("지원하지 않는 JWT 포맷입니다.");
+    }
+
+    @ExceptionHandler(MalformedJwtException.class)
+    public ResponseEntity handleMalformedJwtException(MalformedJwtException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("잘못된 JWT 형식입니다.");
     }
 
 }

--- a/src/main/java/com/prography/minari/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/prography/minari/common/handler/GlobalExceptionHandler.java
@@ -16,8 +16,9 @@ import java.security.SignatureException;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ApiException.class)
-    public ApiResponse handleApiException(ApiException e) {
-        return ApiResponse.fail();
+    public ResponseEntity handleApiException(ApiException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail(e.getErrorCode()));
     }
 
     @ExceptionHandler(ExpiredJwtException.class)

--- a/src/main/java/com/prography/minari/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/prography/minari/common/handler/GlobalExceptionHandler.java
@@ -21,28 +21,4 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(e.getErrorCode()));
     }
 
-    @ExceptionHandler(ExpiredJwtException.class)
-    public ResponseEntity handleExpiredJwtException(ExpiredJwtException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body("토큰이 만료되었습니다.");
-    }
-
-    @ExceptionHandler(SignatureException.class)
-    public ResponseEntity handleSignatureException(SignatureException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body("유효하지 않은 서명입니다.");
-    }
-
-    @ExceptionHandler(UnsupportedJwtException.class)
-    public ResponseEntity handleUnsupportedJwtException(UnsupportedJwtException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body("지원하지 않는 JWT 포맷입니다.");
-    }
-
-    @ExceptionHandler(MalformedJwtException.class)
-    public ResponseEntity handleMalformedJwtException(MalformedJwtException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body("잘못된 JWT 형식입니다.");
-    }
-
 }

--- a/src/main/java/com/prography/minari/common/response/ApiResponse.java
+++ b/src/main/java/com/prography/minari/common/response/ApiResponse.java
@@ -1,18 +1,18 @@
 package com.prography.minari.common.response;
 
 public class ApiResponse<T> {
-    private Integer code;
+    private String code;
     private T result;
 
     public static <T> ApiResponse<T> success(T result) {
-        return new ApiResponse<>(200, result);
+        return new ApiResponse<>("200", result);
     }
 
-    public static <T> ApiResponse<T> fail(Integer code) {
+    public static <T> ApiResponse<T> fail(String code) {
         return new ApiResponse<>(code, null);
     }
 
-    private ApiResponse(Integer code, T result) {
+    private ApiResponse(String code, T result) {
         this.code = code;
         this.result = result;
     }

--- a/src/main/java/com/prography/minari/common/response/ApiResponse.java
+++ b/src/main/java/com/prography/minari/common/response/ApiResponse.java
@@ -17,7 +17,7 @@ public class ApiResponse<T> {
     }
 
     public static <T> ApiResponse<T> fail(T result) {
-        return new ApiResponse<>(201, "불가능한 요청입니다.", result);
+        return new ApiResponse<>(400, "불가능한 요청입니다.", result);
     }
 
     public static ApiResponse<Void> fail() {
@@ -26,6 +26,14 @@ public class ApiResponse<T> {
 
     public static <T> ApiResponse<T> error(T result) {
         return new ApiResponse<>(500, "에러가 발생했습니다.", result);
+    }
+
+    public static <T> ApiResponse<T> unauthorized(T result) {
+        return new ApiResponse<>(401, "인증되지 않은 클라이언트입니다.", result);
+    }
+
+    public static <T> ApiResponse<T> forbidden(T result) {
+        return new ApiResponse<>(403, "권한이 없는 클라이언트입니다.", result);
     }
 
     public static ApiResponse<Void> error() {

--- a/src/main/java/com/prography/minari/common/response/ApiResponse.java
+++ b/src/main/java/com/prography/minari/common/response/ApiResponse.java
@@ -1,48 +1,20 @@
 package com.prography.minari.common.response;
 
-import lombok.Data;
-
-@Data
 public class ApiResponse<T> {
     private Integer code;
-    private String message;
     private T result;
 
     public static <T> ApiResponse<T> success(T result) {
-        return new ApiResponse<>(200, "API 요청이 성공했습니다.", result);
+        return new ApiResponse<>(200, result);
     }
 
-    public static ApiResponse<Void> success() {
-        return success(null);
+    public static <T> ApiResponse<T> fail(Integer code) {
+        return new ApiResponse<>(code, null);
     }
 
-    public static <T> ApiResponse<T> fail(T result) {
-        return new ApiResponse<>(400, "불가능한 요청입니다.", result);
-    }
-
-    public static ApiResponse<Void> fail() {
-        return fail(null);
-    }
-
-    public static <T> ApiResponse<T> error(T result) {
-        return new ApiResponse<>(500, "에러가 발생했습니다.", result);
-    }
-
-    public static <T> ApiResponse<T> unauthorized(T result) {
-        return new ApiResponse<>(401, "인증되지 않은 클라이언트입니다.", result);
-    }
-
-    public static <T> ApiResponse<T> forbidden(T result) {
-        return new ApiResponse<>(403, "권한이 없는 클라이언트입니다.", result);
-    }
-
-    public static ApiResponse<Void> error() {
-        return error(null);
-    }
-
-    private ApiResponse(Integer code, String message, T result) {
+    private ApiResponse(Integer code, T result) {
         this.code = code;
-        this.message = message;
         this.result = result;
     }
+
 }

--- a/src/main/java/com/prography/minari/common/util/JwtUtil.java
+++ b/src/main/java/com/prography/minari/common/util/JwtUtil.java
@@ -1,8 +1,10 @@
 package com.prography.minari.common.util;
 
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import com.prography.minari.common.execption.ApiException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.SignatureException;
 import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +12,7 @@ import java.security.Key;
 import java.util.Date;
 
 @Component
+@Slf4j
 public class JwtUtil {
 
     private final Key key;
@@ -40,9 +43,26 @@ public class JwtUtil {
     }
 
     public void isValidateToken(String token) {
-        Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token);
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+        } catch(ExpiredJwtException e) {
+            log.warn("토큰이 만료되었습니다.");
+            throw new ApiException("JWT001");
+        } catch(SignatureException e) {
+            log.warn("유효하지 않은 서명입니다.");
+            throw new ApiException("JWT002");
+        } catch(UnsupportedJwtException e) {
+            log.warn("지원하지 않는 JWT 포맷입니다.");
+            throw new ApiException("JWT003");
+        } catch(MalformedJwtException e) {
+            log.warn("잘못된 JWT 형식입니다.");
+            throw new ApiException("JWT004");
+        } catch(IllegalStateException e) {
+            log.warn("JWT 파싱 중 예상치 못한 상태 오류가 발생했습니다. 설정 또는 키 값이 올바른지 확인하세요.");
+            throw new ApiException("JWT005");
+        }
     }
 }

--- a/src/main/java/com/prography/minari/common/util/JwtUtil.java
+++ b/src/main/java/com/prography/minari/common/util/JwtUtil.java
@@ -1,0 +1,48 @@
+package com.prography.minari.common.util;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private final Key key;
+    private final Long expiration;
+
+    public JwtUtil(@Value("${jwt.secret}") String secret,
+                    @Value("${jwt.expiration}") Long expiration) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+        this.expiration = expiration;
+    }
+
+    public String createToken(String userId) {
+        return Jwts.builder()
+                .setSubject(userId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getUserId(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public void isValidateToken(String token) {
+        Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+}

--- a/src/main/java/com/prography/minari/social/service/KakaoSocialServiceImpl.java
+++ b/src/main/java/com/prography/minari/social/service/KakaoSocialServiceImpl.java
@@ -1,5 +1,6 @@
 package com.prography.minari.social.service;
 
+import com.prography.minari.common.util.JwtUtil;
 import com.prography.minari.social.dto.social.KakaoTokenInfoResDto;
 import com.prography.minari.social.dto.social.KakaoTokenResDto;
 import com.prography.minari.social.dto.social.KakaoUserInfoResDto;
@@ -33,6 +34,8 @@ public class KakaoSocialServiceImpl implements SocialService {
 
     private final UserRepository userRepository;
 
+    private final JwtUtil jwtUtil;
+
     @Override
     public UserLoginResDto login(String code) {
 
@@ -52,7 +55,10 @@ public class KakaoSocialServiceImpl implements SocialService {
         User user = userRepository.findBySocialTypeAndSocialId(KAKAO, socialId)
                 .orElseGet(() -> userRepository.save(User.create("", KAKAO, socialId, name, image)));
 
-        return UserLoginResDto.from(user);
+        // access token 발급. TODO 차후에 Security 도입 시 로직 수정해야 함.
+        String accessToken = jwtUtil.createToken(user.getId().toString());
+
+        return UserLoginResDto.from(user, accessToken);
     }
 
     // 토큰 받기 https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token

--- a/src/main/java/com/prography/minari/user/dto/UserLoginResDto.java
+++ b/src/main/java/com/prography/minari/user/dto/UserLoginResDto.java
@@ -1,14 +1,17 @@
 package com.prography.minari.user.dto;
 
+import com.prography.minari.common.util.JwtUtil;
 import com.prography.minari.social.dto.enums.SocialType;
 import com.prography.minari.user.entity.User;
 import io.micrometer.common.util.StringUtils;
 
 public record UserLoginResDto(
-        Long id, String email, SocialType socialType, String socialId, String name, String image, Boolean registered)
+        String accessToken, Long id, String email, SocialType socialType, String socialId, String name, String image, Boolean registered)
 {
-    public static UserLoginResDto from(User user) {
+
+    public static UserLoginResDto from(User user, String accessToken) {
         return new UserLoginResDto(
+                accessToken,
                 user.getId(),
                 user.getEmail(),
                 user.getSocialType(),


### PR DESCRIPTION
## #️⃣연관된 이슈

#20 

## 📝작업 내용

### ✏️ Description
> https://sjh9708.tistory.com/170

- 소셜(Kakao) 로그인 시, JWT를 헤더에 담아 응답할 수 있도록 기능 개발

### 🛠 Features
- JWT 라이브러리 등록
- JwtUtil 생성
- JWT에서 발생하는 모든 예외, `@RestControllerAdvice` 등록
  - ExpiredJwtException
  - SignatureException
  - UnsupportedJwtException
  - MalformedJwtException
- 소셜 로그인 성공시, JWT 발급(response body)


## 💬리뷰 요구사항(선택)

- User Controller 응답값은 차후에 새로 Issue 생성해서 다시 pr 하겠습니다!(responseentity -> responseapi, ...)