### PR TITLE
[FEAT(#22)] 인증 메일 전송 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,4 +342,4 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,intellij,intellij+all,intellij+iml,java,gradle,windows
-/src/main/resources/
+/src/main/resources/application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.thymeleaf:thymeleaf'
 
+	// validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,10 @@ dependencies {
 	// google smtp
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	// thymeleaf
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.thymeleaf:thymeleaf'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
+	// google smtp
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/prography/minari/MinariApplication.java
+++ b/src/main/java/com/prography/minari/MinariApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
-@EnableAsync
 public class MinariApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/prography/minari/MinariApplication.java
+++ b/src/main/java/com/prography/minari/MinariApplication.java
@@ -2,8 +2,10 @@ package com.prography.minari;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class MinariApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/prography/minari/common/config/AsyncConfig.java
+++ b/src/main/java/com/prography/minari/common/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.prography.minari.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "threadPoolTaskExecutor")
+    public Executor threadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(3); // 기본 스레드 수
+        executor.setMaxPoolSize(30); // 최대 스레드 수
+        executor.setQueueCapacity(100); // Queue 사이즈
+        executor.setThreadNamePrefix("Executor-");
+        return executor;
+    }
+
+}

--- a/src/main/java/com/prography/minari/common/execption/ErrorCode.java
+++ b/src/main/java/com/prography/minari/common/execption/ErrorCode.java
@@ -2,6 +2,7 @@ package com.prography.minari.common.execption;
 
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 @Getter
 public enum ErrorCode {
@@ -16,7 +17,8 @@ public enum ErrorCode {
     JWT_EXCEPTION(HttpStatus.NOT_FOUND, "JWT 파싱 중 예상치 못한 상태 오류가 발생했습니다. 설정 또는 키 값이 올바른지 확인하세요.","JWT005"),
     EMAIL_INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "잘못된 이메일 주소입니다.", "MAIL001"),
     EMAIL_MESSAGE_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 메시지 생성 중 오류가 발생했습니다.", "MAIL002"),
-    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다.", "MAIL003");
+    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다.", "MAIL003"),
+    METHOD_ARGUMENT_NOT_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "", "VALIDATION");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/prography/minari/common/execption/ErrorCode.java
+++ b/src/main/java/com/prography/minari/common/execption/ErrorCode.java
@@ -13,7 +13,10 @@ public enum ErrorCode {
     JWT_INVALID_SIGNATURE_EXCEPTION(HttpStatus.NOT_FOUND, "유효하지 않은 서명입니다.","JWT002"),
     JWT_UNSUPPORT_FORMAT_EXCEPTION(HttpStatus.NOT_FOUND, "지원하지 않는 JWT 포맷입니다.","JWT003"),
     JWT_WRONG_FORM_EXCEPTION(HttpStatus.NOT_FOUND, "잘못된 JWT 형식입니다.","JWT004"),
-    JWT_EXCEPTION(HttpStatus.NOT_FOUND, "JWT 파싱 중 예상치 못한 상태 오류가 발생했습니다. 설정 또는 키 값이 올바른지 확인하세요.","JWT005");
+    JWT_EXCEPTION(HttpStatus.NOT_FOUND, "JWT 파싱 중 예상치 못한 상태 오류가 발생했습니다. 설정 또는 키 값이 올바른지 확인하세요.","JWT005"),
+    EMAIL_INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "잘못된 이메일 주소입니다.", "MAIL001"),
+    EMAIL_MESSAGE_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 메시지 생성 중 오류가 발생했습니다.", "MAIL002"),
+    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다.", "MAIL003");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/prography/minari/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/prography/minari/common/handler/GlobalExceptionHandler.java
@@ -1,12 +1,15 @@
 package com.prography.minari.common.handler;
 
 import com.prography.minari.common.execption.ApiException;
+import com.prography.minari.common.execption.ErrorCode;
 import com.prography.minari.common.response.ApiResponse;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -18,7 +21,17 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ApiException.class)
     public ResponseEntity handleApiException(ApiException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.fail(e.getErrorCode()));
+                .body(ApiResponse.fail(e.getErrorCode(), null));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> handleValidationException(MethodArgumentNotValidException e) {
+        // 첫 번째 오류만 반환하는 방식
+        FieldError fieldError = e.getBindingResult().getFieldError();
+        String errorMessage = (fieldError != null) ? fieldError.getDefaultMessage() : "유효성 검사에 실패했습니다.";
+
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.fail(ErrorCode.METHOD_ARGUMENT_NOT_VALIDATION_EXCEPTION.getCode(), errorMessage));
     }
 
 }

--- a/src/main/java/com/prography/minari/common/response/ApiResponse.java
+++ b/src/main/java/com/prography/minari/common/response/ApiResponse.java
@@ -17,4 +17,11 @@ public class ApiResponse<T> {
         this.result = result;
     }
 
+    public String getCode() {
+        return code;
+    }
+
+    public T getResult() {
+        return result;
+    }
 }

--- a/src/main/java/com/prography/minari/common/response/ApiResponse.java
+++ b/src/main/java/com/prography/minari/common/response/ApiResponse.java
@@ -8,8 +8,8 @@ public class ApiResponse<T> {
         return new ApiResponse<>("200", result);
     }
 
-    public static <T> ApiResponse<T> fail(String code) {
-        return new ApiResponse<>(code, null);
+    public static <T> ApiResponse<T> fail(String code, T result) {
+        return new ApiResponse<>(code, result);
     }
 
     private ApiResponse(String code, T result) {

--- a/src/main/java/com/prography/minari/mail/dto/MailRequest.java
+++ b/src/main/java/com/prography/minari/mail/dto/MailRequest.java
@@ -1,0 +1,9 @@
+package com.prography.minari.mail.dto;
+
+public record MailRequest(String to, String subject, String content) {
+
+    public static MailRequest create(String to, String subject, String content) {
+        return new MailRequest(to, subject, content);
+    }
+
+}

--- a/src/main/java/com/prography/minari/mail/dto/MailVerificationReqDto.java
+++ b/src/main/java/com/prography/minari/mail/dto/MailVerificationReqDto.java
@@ -1,4 +1,18 @@
 package com.prography.minari.mail.dto;
 
-public record MailVerificationReqDto(String to, String redirectUri) {
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record MailVerificationReqDto(
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @NotBlank(message = "이메일은 필수 입력 값입니다.")
+        String to,
+
+        @Pattern(
+                regexp = "^https?://.+",
+                message = "redirectUri는 http:// 또는 https://로 시작해야 합니다."
+        )
+        @NotBlank(message = "redirectUri는 필수 입력 값입니다.")
+        String redirectUri) {
 }

--- a/src/main/java/com/prography/minari/mail/dto/MailVerificationReqDto.java
+++ b/src/main/java/com/prography/minari/mail/dto/MailVerificationReqDto.java
@@ -1,0 +1,4 @@
+package com.prography.minari.mail.dto;
+
+public record MailVerificationReqDto(String to, String redirectUri) {
+}

--- a/src/main/java/com/prography/minari/mail/service/MailService.java
+++ b/src/main/java/com/prography/minari/mail/service/MailService.java
@@ -1,0 +1,35 @@
+package com.prography.minari.mail.service;
+
+import com.prography.minari.common.util.JwtUtil;
+import com.prography.minari.mail.dto.MailRequest;
+import com.prography.minari.mail.dto.MailVerificationReqDto;
+import com.prography.minari.mail.service.impl.GoogleMailClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private static final String AUTH_SUBJECT = "[미래의 나를 위한 리워드] 이메일 인증을 완료해주세요.";
+
+    private final GoogleMailClient googleMailClient;
+    private final TemplateEngine templateEngine;
+
+    public void sendAuthMail(MailVerificationReqDto mailVerificationReqDto) {
+        // 인증 메일 양식 만들기
+        MailRequest authMailRequest = createAuthMailTemplate(mailVerificationReqDto.to(), mailVerificationReqDto.redirectUri());
+        // 인증 메일 전송
+        googleMailClient.sendMail(authMailRequest);
+    }
+
+    private MailRequest createAuthMailTemplate(String to, String redirectUri) {
+        Context context = new Context();
+        context.setVariable("verificationLink", redirectUri);
+        String autContents = templateEngine.process("auth-mail", context);
+        return MailRequest.create(to, AUTH_SUBJECT, autContents);
+    }
+
+}

--- a/src/main/java/com/prography/minari/mail/service/impl/GoogleMailClient.java
+++ b/src/main/java/com/prography/minari/mail/service/impl/GoogleMailClient.java
@@ -1,0 +1,46 @@
+package com.prography.minari.mail.service.impl;
+
+import com.prography.minari.common.aop.ImplService;
+import com.prography.minari.common.execption.ApiException;
+import com.prography.minari.common.execption.ErrorCode;
+import com.prography.minari.mail.dto.MailRequest;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import static com.prography.minari.common.execption.ErrorCode.*;
+
+@ImplService
+@Slf4j
+@RequiredArgsConstructor
+public class GoogleMailClient {
+
+    private final JavaMailSender javaMailSender;
+
+    public void sendMail(MailRequest mailRequest) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+        try{
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            mimeMessageHelper.setTo(mailRequest.to());                    // 메일을 받을 수신자 설정
+            mimeMessageHelper.setSubject(mailRequest.subject());          // 메일의 제목 설정
+            mimeMessageHelper.setText(mailRequest.content(), true); // 메일의 내용 설정
+            javaMailSender.send(mimeMessage);
+        } catch (AddressException e) {
+            log.error("잘못된 이메일 주소입니다: {}", mailRequest.to(), e);
+            throw new ApiException(EMAIL_INVALID_ADDRESS);
+        } catch (MessagingException e) {
+            log.error("메일 전송 중 MessagingException 발생", e);
+            throw new ApiException(EMAIL_MESSAGE_CREATION_FAILED);
+        } catch (MailException e) {
+            log.error("Spring Mail 전송 실패", e);
+            throw new ApiException(EMAIL_SEND_FAILED);
+        }
+    }
+
+}

--- a/src/main/java/com/prography/minari/mail/service/impl/GoogleMailClient.java
+++ b/src/main/java/com/prography/minari/mail/service/impl/GoogleMailClient.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 
 import static com.prography.minari.common.execption.ErrorCode.*;
 
@@ -22,6 +23,7 @@ public class GoogleMailClient {
 
     private final JavaMailSender javaMailSender;
 
+    @Async
     public void sendMail(MailRequest mailRequest) {
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
 

--- a/src/main/java/com/prography/minari/user/controller/UserController.java
+++ b/src/main/java/com/prography/minari/user/controller/UserController.java
@@ -9,6 +9,7 @@ import com.prography.minari.user.dto.UserLoginResDto;
 import com.prography.minari.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -28,7 +29,7 @@ public class UserController {
     }
 
     @PostMapping("/users/mail-verification")
-    public ResponseEntity emailVerification(@RequestBody MailVerificationReqDto mailVerificationReqDto) {
+    public ResponseEntity emailVerification(@RequestBody @Validated MailVerificationReqDto mailVerificationReqDto) {
         mailService.sendAuthMail(mailVerificationReqDto);
         return ResponseEntity.ok(ApiResponse.success(null));
     }

--- a/src/main/java/com/prography/minari/user/controller/UserController.java
+++ b/src/main/java/com/prography/minari/user/controller/UserController.java
@@ -1,5 +1,8 @@
 package com.prography.minari.user.controller;
 
+import com.prography.minari.common.response.ApiResponse;
+import com.prography.minari.mail.dto.MailVerificationReqDto;
+import com.prography.minari.mail.service.MailService;
 import com.prography.minari.social.dto.enums.SocialType;
 import com.prography.minari.social.service.SocialService;
 import com.prography.minari.user.dto.UserLoginResDto;
@@ -16,11 +19,18 @@ public class UserController {
 
     private final UserService userService;
     private final SocialService socialService;
+    private final MailService mailService;
 
     @GetMapping("/users/oauth/{social}")
     public ResponseEntity oauth(@RequestParam("code") String code, @RequestParam("redirect-uri") String redirectUri, @PathVariable("social") String socialType) {
         UserLoginResDto userLoginResDto = socialService.login(SocialType.from(socialType), code, redirectUri);
         return ResponseEntity.ok(userLoginResDto);
+    }
+
+    @PostMapping("/users/mail-verification")
+    public ResponseEntity emailVerification(@RequestBody MailVerificationReqDto mailVerificationReqDto) {
+        mailService.sendAuthMail(mailVerificationReqDto);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     @GetMapping("/users/{id}")

--- a/src/main/resources/templates/auth-mail.html
+++ b/src/main/resources/templates/auth-mail.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+</head>
+<body>
+<h2>이메일 인증</h2>
+<p>아래 버튼을 눌러 이메일 인증을 완료해 주세요.</p>
+<a th:href="${verificationLink}"
+   style="display:inline-block; padding:10px 20px; background-color:#4CAF50; color:white; text-decoration:none; border-radius:5px;">
+  이메일 인증하기
+</a>
+<p>인증 링크는 10분 동안만 유효합니다.</p>
+</body>
+</html>


### PR DESCRIPTION
## #️⃣연관된 이슈

#22 

## 📝작업 내용

### build.gradle 라이브러리 추가
#### 📄 build.gradle
```build.gradle
    // google smtp
    implementation 'org.springframework.boot:spring-boot-starter-mail'

    // thymeleaf
    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
    implementation 'org.thymeleaf:thymeleaf'

    // validation
    implementation 'org.springframework.boot:spring-boot-starter-validation'
```

---

### 메일 환경설정 파일

#### 📄 MailConfig.java
```java
@Configuration
public class MailConfig {

    private static final String MAIL_TRANSPORT_PROTOCOL = "mail.transport.protocol";
    private static final String MAIL_SMTP_AUTH = "mail.smtp.auth";
    private static final String MAIL_SMTP_STARTTLS_ENABLE = "mail.smtp.starttls.enable";
    private static final String MAIL_DEBUG = "mail.debug";
    private static final String TRUE = "true";
    private static final String SMTP = "smtp";


    @Value("${google.mail.host:default}")
    private String host;

    @Value("${google.mail.port:default}")
    private Integer port;

    @Value("${google.mail.username:default}")
    private String username;

    @Value("${google.mail.password:default}")
    private String password;


    @Bean
    public JavaMailSender javaMailSender() {
        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
        mailSender.setHost(host);
        mailSender.setPort(port);
        mailSender.setUsername(username);
        mailSender.setPassword(password);

        Properties props = mailSender.getJavaMailProperties();
        props.put(MAIL_TRANSPORT_PROTOCOL, SMTP);
        props.put(MAIL_SMTP_AUTH, TRUE);
        props.put(MAIL_SMTP_STARTTLS_ENABLE, TRUE);
        props.put(MAIL_DEBUG, TRUE);

        return mailSender;
    }

}
```

---

### 이메일 전송 오류 ErrorCode

#### 📄 ErrorCode.java
```java
    EMAIL_INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "잘못된 이메일 주소입니다.", "MAIL001"),
    EMAIL_MESSAGE_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 메시지 생성 중 오류가 발생했습니다.", "MAIL002"),
    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다.", "MAIL003");
```

### 직렬화를 위한 `ApiResponse` Getter 추가

### mail template 생성

#### 📄 auth-mail.html
```html
<!DOCTYPE html>
<html xmlns:th="http://www.thymeleaf.org">
<head>
  <meta charset="UTF-8">
</head>
<body>
<h2>이메일 인증</h2>
<p>아래 버튼을 눌러 이메일 인증을 완료해 주세요.</p>
<a th:href="${verificationLink}"
   style="display:inline-block; padding:10px 20px; background-color:#4CAF50; color:white; text-decoration:none; border-radius:5px;">
  이메일 인증하기
</a>
<p>인증 링크는 10분 동안만 유효합니다.</p>
</body>
</html>
```

---

### 🔥 인증 메일 전송 기능 개발
https://github.com/prography/10th-3team-minari-BE/commit/46f938a2d0bba1b8c97bfd554197121f911ec982

- `{server}/api/v1//users/mail-verification` 이메일 인증을 위한 API 개발
- `GoogleMailClient` 구현체를 통해 메일 전송 기능 개발
- `MailService` 서비스 레이어를 통해 인증 메일 전송 기능 개발
- ❗️ 인증 검증 로직 : JWT로 인증된 유저만 해당 API에 접근할 수 있도록 할 예정 (Spring Security 도입 이후)

---

### 비동기 처리를 위한 `@Async` 
- 메일 전송 구현체인 `GoogleMailClient`에 `@Async` 어노테이션 추가
- `MinariApplication.java`에 `@EnableAsync` 어노테이션 추가

---

### 유효성 검증을 위한 `@Validation` 추가
#### 📄 MailVerificationReqDto.java
```java
public record MailVerificationReqDto(
        @Email(message = "이메일 형식이 올바르지 않습니다.")
        @NotBlank(message = "이메일은 필수 입력 값입니다.")
        String to,

        @Pattern(
                regexp = "^https?://.+",
                message = "redirectUri는 http:// 또는 https://로 시작해야 합니다."
        )
        @NotBlank(message = "redirectUri는 필수 입력 값입니다.")
        String redirectUri) {
}
```

---

## 💬리뷰 요구사항(선택)

> 메일 도메인에 대한 레이어가 괜찮은지 강력한 피드백 부탁드립니다!! @jaepyo-Lee 