### PR TITLE
[Feat(#3)] Stt변환 로직에 1분으로 파일 자르는 로직 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -343,3 +343,4 @@ gradle-app.setting
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,intellij,intellij+all,intellij+iml,java,gradle,windows
 /src/main/resources/application.yml
+/src/main/resources/application-local.yml

--- a/src/main/java/com/prography/minari/answer/controller/AnswerController.java
+++ b/src/main/java/com/prography/minari/answer/controller/AnswerController.java
@@ -18,12 +18,11 @@ public class AnswerController implements AnswerApiDocs {
     // STT변환 API
     @PostMapping("/{userId}/questions/{questionId}")
     public ResponseEntity<InterviewContentResponse> convertToText(@RequestParam("file") MultipartFile file,
-                                                                  @PathVariable Long questionId,
-                                                                  @PathVariable Long userId) {
+                                                                  @PathVariable("questionId") Long questionId,
+                                                                  @PathVariable("userId") Long userId) {
         InterviewContentResponse interviewContentResponse = answerService.writeUserSpeech(file, userId, questionId);
         return ResponseEntity.ok(interviewContentResponse);
     }
-
 
     // STT변환진행상태조회
     @GetMapping("/{userId}/questions/{questionId}/status")

--- a/src/main/java/com/prography/minari/answer/service/AnswerService.java
+++ b/src/main/java/com/prography/minari/answer/service/AnswerService.java
@@ -32,19 +32,15 @@ public class AnswerService {
 
     public InterviewContentResponse writeUserSpeech(MultipartFile file, Long userId, Long questionId) {
         User user = userReader.read(userId);
-        String speech = sttProcessor.convertToText(file);
         Question question = questionReader.read(questionId)
                 .orElseThrow(() -> new ApiException(ErrorCode.QUESTION_NOT_FOUND));
+        String speech = sttProcessor.convertToText(file);
         answerWriter.write(Answer.builder()
                 .reply(speech)
                 .user(user)
                 .question(question)
                 .build());
-        return InterviewContentResponse.builder()
-                .answer(question.getAnswer())
-                .reply(speech)
-                .question(question.getContent())
-                .build();
+        return InterviewContentResponse.of(question.getAnswer(), question.getContent(), speech);
     }
 
     public UserAnswerStatusResponse getSttProcessStatus(Long userId, Long questionId) {

--- a/src/main/java/com/prography/minari/answer/service/dto/SttResponseDto.java
+++ b/src/main/java/com/prography/minari/answer/service/dto/SttResponseDto.java
@@ -1,0 +1,11 @@
+package com.prography.minari.answer.service.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SttResponseDto {
+    @Getter
+    public static class Naver {
+        private String text;
+    }
+}

--- a/src/main/java/com/prography/minari/answer/service/dto/response/InterviewContentResponse.java
+++ b/src/main/java/com/prography/minari/answer/service/dto/response/InterviewContentResponse.java
@@ -9,4 +9,8 @@ public class InterviewContentResponse {
     private String answer;
     private String question;
     private String reply;
+
+    public static InterviewContentResponse of(String answer, String question, String reply) {
+        return new InterviewContentResponse(answer, question, reply);
+    }
 }

--- a/src/main/java/com/prography/minari/answer/service/impl/NaverApiClient.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/NaverApiClient.java
@@ -1,6 +1,7 @@
 package com.prography.minari.answer.service.impl;
 
 
+import com.prography.minari.answer.service.dto.SttResponseDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -24,9 +25,9 @@ public class NaverApiClient implements SttApiClient {
 
 
     @Override
-    public String convertToText(MultipartFile voiceFile) {
+    public String convertToText(byte[] voiceFile) {
         try {
-            return webClient.post()
+            SttResponseDto.Naver block = webClient.post()
                     .uri(uriBuilder -> uriBuilder
                             .path("/recog/v1/stt")
                             .queryParam("lang", "Kor")
@@ -34,10 +35,11 @@ public class NaverApiClient implements SttApiClient {
                     .header("X-NCP-APIGW-API-KEY-ID", clientId)
                     .header("X-NCP-APIGW-API-KEY", clientSecret)
                     .contentType(MediaType.APPLICATION_OCTET_STREAM)
-                    .bodyValue(voiceFile.getBytes())
+                    .bodyValue(voiceFile)
                     .retrieve()
-                    .bodyToMono(String.class)
+                    .bodyToMono(SttResponseDto.Naver.class)
                     .block();
+            return block.getText();
         } catch (Exception e) {
             throw new RuntimeException("STT API 호출 실패", e);
         }

--- a/src/main/java/com/prography/minari/answer/service/impl/SttApiClient.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/SttApiClient.java
@@ -3,5 +3,5 @@ package com.prography.minari.answer.service.impl;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface SttApiClient {
-    String convertToText(MultipartFile file);
+    String convertToText(byte[] file);
 }

--- a/src/main/java/com/prography/minari/answer/service/impl/SttProcessor.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/SttProcessor.java
@@ -2,15 +2,98 @@ package com.prography.minari.answer.service.impl;
 
 import com.prography.minari.common.aop.ImplService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.sound.sampled.AudioFileFormat;
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
 @ImplService
 @RequiredArgsConstructor
 public class SttProcessor {
     private final SttApiClient sttApiClient;
 
     public String convertToText(MultipartFile file) {
-        return sttApiClient.convertToText(file);
+        try {
+            AudioFormat format = getAudioFormat(file);
+            List<byte[]> rawChunks = splitWavToExactMinutes(file, format);
+            List<String> texts = rawChunks.stream()
+                    .map(chunk -> {
+                        try {
+                            byte[] wavChunk = toAutioFormatBytes(chunk, format);
+                            return sttApiClient.convertToText(wavChunk);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .toList();
+
+            return texts.stream()
+                    .filter(s -> !s.isBlank())
+                    .map(s -> s.endsWith(".") ? s : s + ".")
+                    .collect(Collectors.joining(" "));
+
+        } catch (Exception e) {
+            throw new RuntimeException("STT 변환 실패", e);
+        }
+    }
+
+    private AudioFormat getAudioFormat(MultipartFile file) throws Exception {
+        try (InputStream is = new BufferedInputStream(file.getInputStream());
+             AudioInputStream fullStream = AudioSystem.getAudioInputStream(is)) {
+            return fullStream.getFormat();
+        }
+    }
+
+    private List<byte[]> splitWavToExactMinutes(MultipartFile file, AudioFormat format) throws Exception {
+        try (InputStream is = new BufferedInputStream(file.getInputStream());
+             AudioInputStream fullStream = AudioSystem.getAudioInputStream(is)) {
+
+            float frameRate = format.getFrameRate();     // ex: 44100.0
+            int frameSize = format.getFrameSize();       // ex: 4 (16bit stereo)
+
+            int bytesPerMinute = (int) (frameRate * frameSize * 60); // 정확히 1분 분량
+            List<byte[]> chunks = new ArrayList<>();
+
+            byte[] buffer = new byte[bytesPerMinute];
+            int offset = 0;
+
+            int bytesRead;
+            while ((bytesRead = fullStream.read(buffer, offset, buffer.length - offset)) != -1) {
+                offset += bytesRead;
+
+                // 1분 분량이 꽉 찼을 때만 추가
+                if (offset == buffer.length) {
+                    chunks.add(Arrays.copyOf(buffer, buffer.length));
+                    offset = 0;
+                }
+            }
+
+            // 마지막 덜 찬 chunk도 추가
+            if (offset > 0) {
+                chunks.add(Arrays.copyOf(buffer, offset));
+            }
+
+            return chunks;
+        }
+    }
+
+    private byte[] toAutioFormatBytes(byte[] rawData, AudioFormat format) throws IOException {
+        try (
+                ByteArrayInputStream bais = new ByteArrayInputStream(rawData);
+                ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        ) {
+            AudioInputStream chunkStream = new AudioInputStream(bais, format, rawData.length / format.getFrameSize());
+            AudioSystem.write(chunkStream, AudioFileFormat.Type.WAVE, baos);
+            return baos.toByteArray();
+        }
     }
 }

--- a/src/main/java/com/prography/minari/answer/service/impl/SttProcessor.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/SttProcessor.java
@@ -1,14 +1,13 @@
 package com.prography.minari.answer.service.impl;
 
 import com.prography.minari.common.aop.ImplService;
+import com.prography.minari.common.execption.ApiException;
+import com.prography.minari.common.execption.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.sound.sampled.AudioFileFormat;
-import javax.sound.sampled.AudioFormat;
-import javax.sound.sampled.AudioInputStream;
-import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.*;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,38 +21,40 @@ public class SttProcessor {
     private final SttApiClient sttApiClient;
 
     public String convertToText(MultipartFile file) {
-        try {
-            AudioFormat format = getAudioFormat(file);
-            List<byte[]> rawChunks = splitWavToExactMinutes(file, format);
-            List<String> texts = rawChunks.stream()
-                    .map(chunk -> {
-                        try {
-                            byte[] wavChunk = toAutioFormatBytes(chunk, format);
-                            return sttApiClient.convertToText(wavChunk);
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
-                        }
-                    })
-                    .toList();
+        AudioFormat format = getAudioFormat(file);
+        List<byte[]> rawChunks = splitWavToExactMinutes(file, format);
+        List<String> texts = rawChunks.stream()
+                .map(chunk -> {
+                    try {
+                        byte[] wavChunk = toAutioFormatBytes(chunk, format);
+                        return sttApiClient.convertToText(wavChunk);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .toList();
 
-            return texts.stream()
-                    .filter(s -> !s.isBlank())
-                    .map(s -> s.endsWith(".") ? s : s + ".")
-                    .collect(Collectors.joining(" "));
+        return texts.stream()
+                .filter(s -> !s.isBlank())
+                .map(s -> s.endsWith(".") ? s : s + ".")
+                .collect(Collectors.joining(" "));
 
-        } catch (Exception e) {
-            throw new RuntimeException("STT 변환 실패", e);
-        }
     }
 
-    private AudioFormat getAudioFormat(MultipartFile file) throws Exception {
+    private AudioFormat getAudioFormat(MultipartFile file) {
         try (InputStream is = new BufferedInputStream(file.getInputStream());
              AudioInputStream fullStream = AudioSystem.getAudioInputStream(is)) {
             return fullStream.getFormat();
+        } catch (UnsupportedAudioFileException e) {
+            log.error("지원하지 않는 오디오 포맷: {}",e.getMessage());
+            throw new ApiException(ErrorCode.AUDIO_UNSUPPORT_FORMAT_EXCEPTION);
+        } catch (IOException e) {
+            log.error("오디오 파일 처리 중 IO 오류 발생: {}",e.getMessage());
+            throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 
-    private List<byte[]> splitWavToExactMinutes(MultipartFile file, AudioFormat format) throws Exception {
+    private List<byte[]> splitWavToExactMinutes(MultipartFile file, AudioFormat format) {
         try (InputStream is = new BufferedInputStream(file.getInputStream());
              AudioInputStream fullStream = AudioSystem.getAudioInputStream(is)) {
 
@@ -83,6 +84,12 @@ public class SttProcessor {
             }
 
             return chunks;
+        }catch (UnsupportedAudioFileException e) {
+            log.error("지원하지 않는 오디오 포맷: {}",e.getMessage());
+            throw new ApiException(ErrorCode.AUDIO_UNSUPPORT_FORMAT_EXCEPTION);
+        } catch (IOException e) {
+            log.error("오디오 파일 처리 중 IO 오류 발생: {}",e.getMessage());
+            throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/com/prography/minari/common/execption/ErrorCode.java
+++ b/src/main/java/com/prography/minari/common/execption/ErrorCode.java
@@ -18,7 +18,8 @@ public enum ErrorCode {
     EMAIL_INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "잘못된 이메일 주소입니다.", "MAIL001"),
     EMAIL_MESSAGE_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 메시지 생성 중 오류가 발생했습니다.", "MAIL002"),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다.", "MAIL003"),
-    METHOD_ARGUMENT_NOT_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "", "VALIDATION");
+    METHOD_ARGUMENT_NOT_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "", "VALIDATION"),
+    AUDIO_UNSUPPORT_FORMAT_EXCEPTION(HttpStatus.NOT_FOUND, "지원하지 않는 오디오 포맷입니다.","AU003"),;
 
     private final HttpStatus status;
     private final String message;

--- a/src/test/java/com/prography/minari/answer/service/impl/SttApiClientTest.java
+++ b/src/test/java/com/prography/minari/answer/service/impl/SttApiClientTest.java
@@ -50,6 +50,8 @@ class SttApiClientTest {
         MultipartFile mockFile = new MockMultipartFile(
                 "file", "test.wav", "audio/wav", "dummy audio".getBytes()
         );
+
+        byte[] bytes = mockFile.getBytes();
         String expectedText = "{\"text\":\"테스트입니다\"}";
 
         mockWebServer.enqueue(new MockResponse()
@@ -60,7 +62,7 @@ class SttApiClientTest {
                 .setBody(expectedText));
 
         // when
-        String result = sttApiClient.convertToText(mockFile);
+        String result = sttApiClient.convertToText(bytes);
 
         // then
         assertEquals(expectedText, result);
@@ -78,7 +80,7 @@ class SttApiClientTest {
 
     @Test
     @DisplayName("")
-    void STT호출테스트_API_400_서버에러_테스트() {
+    void STT호출테스트_API_400_서버에러_테스트() throws IOException {
         // given
         mockWebServer.enqueue(new MockResponse()
                 .setResponseCode(400)
@@ -88,10 +90,10 @@ class SttApiClientTest {
         MultipartFile mockFile = new MockMultipartFile(
                 "file", "test.wav", "audio/wav", "dummy audio".getBytes()
         );
-
+        byte[] bytes = mockFile.getBytes();
         // when & then
         RuntimeException ex = assertThrows(RuntimeException.class, () ->
-                sttApiClient.convertToText(mockFile)
+                sttApiClient.convertToText(bytes)
         );
         assertTrue(ex.getMessage().contains("STT API 호출 "));
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
#3 

## 📝작업 내용
- 최대 5분파일 1분씩 나눠 stt api호출

## 💬리뷰 요구사항(선택)
- 코드가 많아지니 점점 구현체 나누는게 어려워지네여...
- 오디오를 자르는 로직은 STT를 위한 로직이라 생각해서 SttProccessor에 넣었는데, 상현님은 어떻게 생각하시나요??