### PR TITLE
[Feat(#18)] 오늘의 미나리 조회기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	//spring
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation "org.junit.platform:junit-platform-launcher:1.11.0"
+//	testImplementation "org.junit.platform:junit-platform-launcher:1.11.0"
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
 	//webserver
@@ -41,7 +41,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	// fixture monkey
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher:{version}")
+//	testRuntimeOnly("org.junit.platform:junit-platform-launcher:{version}")
 	testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.11")
 
 	// webflux

--- a/src/main/java/com/prography/minari/common/entity/Domain.java
+++ b/src/main/java/com/prography/minari/common/entity/Domain.java
@@ -1,0 +1,5 @@
+package com.prography.minari.common.entity;
+
+public enum Domain {
+    BACKEND,FRONTEND,CS
+}

--- a/src/main/java/com/prography/minari/question/DailyUserQuestionResDto.java
+++ b/src/main/java/com/prography/minari/question/DailyUserQuestionResDto.java
@@ -1,0 +1,11 @@
+package com.prography.minari.question;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DailyUserQuestionResDto {
+    private Long questionId;
+    private String contents;
+}

--- a/src/main/java/com/prography/minari/question/controller/QuestionController.java
+++ b/src/main/java/com/prography/minari/question/controller/QuestionController.java
@@ -1,5 +1,7 @@
 package com.prography.minari.question.controller;
 
+import com.prography.minari.common.response.ApiResponse;
+import com.prography.minari.question.DailyUserQuestionResDto;
 import com.prography.minari.question.controller.docs.QuestionApiDocs;
 import com.prography.minari.question.service.QuestionService;
 import jakarta.servlet.http.HttpServletResponse;
@@ -17,5 +19,10 @@ public class QuestionController implements QuestionApiDocs {
     @GetMapping("/questions/{questionId}/contents")
     public String getQuestion(@PathVariable Long questionId) {
         return questionService.readContents(questionId);
+    }
+
+    @GetMapping("/users/{userId}/questions")
+    public ApiResponse<DailyUserQuestionResDto> getDailyQuestion(@PathVariable("userId")Long userId){
+        return ApiResponse.success(questionService.readDaily(userId));
     }
 }

--- a/src/main/java/com/prography/minari/question/controller/QuestionController.java
+++ b/src/main/java/com/prography/minari/question/controller/QuestionController.java
@@ -4,25 +4,32 @@ import com.prography.minari.common.response.ApiResponse;
 import com.prography.minari.question.DailyUserQuestionResDto;
 import com.prography.minari.question.controller.docs.QuestionApiDocs;
 import com.prography.minari.question.service.QuestionService;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class QuestionController implements QuestionApiDocs {
     private final QuestionService questionService;
+
     @GetMapping("/questions/{questionId}/contents")
     public String getQuestion(@PathVariable Long questionId) {
         return questionService.readContents(questionId);
     }
 
     @GetMapping("/users/{userId}/questions")
-    public ApiResponse<DailyUserQuestionResDto> getDailyQuestion(@PathVariable("userId")Long userId){
+    public ApiResponse<DailyUserQuestionResDto> getDailyQuestion(@PathVariable("userId") Long userId) {
         return ApiResponse.success(questionService.readDaily(userId));
+    }
+
+    @GetMapping("/questions/{questionId}/tag")
+    public ApiResponse<List<String>> getTags(@PathVariable("questionId") Long questionId) {
+        return ApiResponse.success(questionService.readTags(questionId));
     }
 }

--- a/src/main/java/com/prography/minari/question/entity/Level.java
+++ b/src/main/java/com/prography/minari/question/entity/Level.java
@@ -1,0 +1,5 @@
+package com.prography.minari.question.entity;
+
+public enum Level {
+    EASY,MEDIUM,HARD
+}

--- a/src/main/java/com/prography/minari/question/entity/Question.java
+++ b/src/main/java/com/prography/minari/question/entity/Question.java
@@ -1,7 +1,9 @@
 package com.prography.minari.question.entity;
 
 import com.prography.minari.common.entity.BaseTimeEntity;
+import com.prography.minari.common.entity.Domain;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,10 +17,22 @@ public class Question extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
     @Column(nullable = false,name = "content")
     private String content;
+    @NotNull
     @Column(nullable = false,name = "answer")
     private String answer;
+    @NotNull
     @Column(nullable = false,name = "tag")
     private String tag;
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Level level;
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Domain domain;
+    @NotNull
+    @Column(nullable = false,name = "order_num")
+    private int orderNum;
 }

--- a/src/main/java/com/prography/minari/question/entity/Question.java
+++ b/src/main/java/com/prography/minari/question/entity/Question.java
@@ -8,6 +8,14 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.stream;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -18,13 +26,13 @@ public class Question extends BaseTimeEntity {
     private Long id;
 
     @NotNull
-    @Column(nullable = false,name = "content")
+    @Column(nullable = false, name = "content")
     private String content;
     @NotNull
-    @Column(nullable = false,name = "answer")
+    @Column(nullable = false, name = "answer")
     private String answer;
     @NotNull
-    @Column(nullable = false,name = "tag")
+    @Column(nullable = false, name = "tag")
     private String tag;
     @NotNull
     @Enumerated(EnumType.STRING)
@@ -33,6 +41,19 @@ public class Question extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Domain domain;
     @NotNull
-    @Column(nullable = false,name = "order_num")
+    @Column(nullable = false, name = "order_num")
     private int orderNum;
+
+    public List<String> getTags() {
+        return Arrays.stream(tag.split(","))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    public List<String>getShuffledTags(int size) {
+        List<String> tags = getTags();
+        Collections.shuffle(tags);
+        int count = Math.min(tags.size(), size);
+        return tags.subList(0, count);
+    }
+
 }

--- a/src/main/java/com/prography/minari/question/repository/QuestionRepository.java
+++ b/src/main/java/com/prography/minari/question/repository/QuestionRepository.java
@@ -1,9 +1,31 @@
 package com.prography.minari.question.repository;
 
+import com.prography.minari.common.entity.Domain;
 import com.prography.minari.question.entity.Question;
+import com.prography.minari.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    @Query("""
+    SELECT q
+    FROM Question q
+    LEFT JOIN Answer a ON a.question = q AND a.user.id = :userId
+    WHERE (:domains IS NULL OR q.domain IN :domains)
+      AND a.id IS NULL
+    ORDER BY q.orderNum ASC
+    """)
+    Page<Question> findDailyUnsolvedQuestionByDomains(
+            @Param("userId") Long userId,
+            @Param("domains") List<Domain> domains,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/prography/minari/question/service/QuestionService.java
+++ b/src/main/java/com/prography/minari/question/service/QuestionService.java
@@ -11,6 +11,7 @@ import com.prography.minari.user.service.impl.UserReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,6 +24,11 @@ public class QuestionService {
     public String readContents(Long id) {
         Question question = questionReader.read(id).orElseThrow(() -> new ApiException(ErrorCode.QUESTION_NOT_FOUND));
         return question.getContent();
+    }
+
+    public List<String> readTags(Long questionId) {
+        Question question = questionReader.read(questionId).orElseThrow(()->new ApiException(ErrorCode.QUESTION_NOT_FOUND));
+        return question.getShuffledTags(3);
     }
 
     public DailyUserQuestionResDto readDaily(Long userId) {

--- a/src/main/java/com/prography/minari/question/service/QuestionService.java
+++ b/src/main/java/com/prography/minari/question/service/QuestionService.java
@@ -1,21 +1,37 @@
 package com.prography.minari.question.service;
 
+import com.prography.minari.common.entity.Domain;
 import com.prography.minari.common.execption.ApiException;
 import com.prography.minari.common.execption.ErrorCode;
+import com.prography.minari.question.DailyUserQuestionResDto;
 import com.prography.minari.question.entity.Question;
 import com.prography.minari.question.service.impl.QuestionReader;
+import com.prography.minari.user.entity.User;
+import com.prography.minari.user.service.impl.UserReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class QuestionService {
     private final QuestionReader questionReader;
+    private final UserReader userReader;
 
     public String readContents(Long id) {
         Question question = questionReader.read(id).orElseThrow(() -> new ApiException(ErrorCode.QUESTION_NOT_FOUND));
         return question.getContent();
+    }
+
+    public DailyUserQuestionResDto readDaily(Long userId) {
+        User user = userReader.read(userId);
+        Long daysBetween = user.getDaysSinceJoined();
+        List<Domain> domains = user.getPreferDomains();
+        Optional<Question> question = questionReader.readDaily(user, domains, daysBetween);
+        return question
+                .map(q -> new DailyUserQuestionResDto(q.getId(), q.getContent()))
+                .orElseThrow(() -> new ApiException(ErrorCode.QUESTION_NOT_FOUND));
     }
 }

--- a/src/main/java/com/prography/minari/question/service/impl/QuestionReader.java
+++ b/src/main/java/com/prography/minari/question/service/impl/QuestionReader.java
@@ -1,21 +1,29 @@
 package com.prography.minari.question.service.impl;
 
 import com.prography.minari.common.aop.ImplService;
+import com.prography.minari.common.entity.Domain;
 import com.prography.minari.question.entity.Question;
 import com.prography.minari.question.repository.QuestionRepository;
+import com.prography.minari.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @ImplService
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class QuestionReader {
     private final QuestionRepository questionRepository;
 
-    @Transactional(readOnly = true)
     public Optional<Question> read(Long id) {
         return questionRepository.findById(id);
+    }
+
+    public Optional<Question> readDaily(User user, List<Domain> domains, long day) {
+        return Optional.ofNullable(questionRepository.findDailyUnsolvedQuestionByDomains(user.getId(), domains, PageRequest.of((int) day, 1)).getContent().getFirst());
     }
 }

--- a/src/main/java/com/prography/minari/user/entity/PreferDomain.java
+++ b/src/main/java/com/prography/minari/user/entity/PreferDomain.java
@@ -1,0 +1,23 @@
+package com.prography.minari.user.entity;
+
+import com.prography.minari.common.entity.Domain;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+
+@Entity
+@Table(name = "PREFER_DOMAIN")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class PreferDomain {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Domain name;
+}

--- a/src/main/java/com/prography/minari/user/entity/User.java
+++ b/src/main/java/com/prography/minari/user/entity/User.java
@@ -1,11 +1,18 @@
 package com.prography.minari.user.entity;
 
 import com.prography.minari.common.entity.BaseTimeEntity;
+import com.prography.minari.common.entity.Domain;
 import com.prography.minari.social.dto.enums.SocialType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.EnumType.STRING;
 
@@ -33,6 +40,10 @@ public class User extends BaseTimeEntity {
 
     private Boolean registered;
 
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "user_id") // FK를 이쪽에서 관리
+    private List<PreferDomain> preferDomains = new ArrayList<>();
+
     public static User create(String email, SocialType socialType, Long socialId, String name, String image) {
         User user = new User();
         user.email = email;
@@ -44,4 +55,15 @@ public class User extends BaseTimeEntity {
         return user;
     }
 
+    public List<Domain> getPreferDomains() {
+        return preferDomains.stream()
+                .map(PreferDomain::getName)
+                .toList();
+    }
+
+    public Long getDaysSinceJoined() {
+        LocalDate now = LocalDateTime.now().toLocalDate();
+        LocalDate created = getCreatedDateTime().toLocalDate();
+        return ChronoUnit.DAYS.between(created, now);
+    }
 }

--- a/src/test/java/com/prography/minari/question/entity/QuestionTest.java
+++ b/src/test/java/com/prography/minari/question/entity/QuestionTest.java
@@ -1,0 +1,51 @@
+package com.prography.minari.question.entity;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class QuestionTest {
+    private FixtureMonkey fixtureMonkey;
+    @BeforeEach
+    void setUp() {
+        fixtureMonkey = FixtureMonkey.builder()
+                .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+                .build();
+    }
+    @Test
+    void 태그조회테스트() {
+        // given
+        Question sample = fixtureMonkey.giveMeBuilder(Question.class)
+                .set("tag", "right,left,middle,right")
+                .sample();
+        // when
+        // then
+        assertThat(sample.getTags().size()).isEqualTo(4);
+    }
+
+    @Test
+    void 특정크기의태그조회테스트() {
+        // given
+        Question sample = fixtureMonkey.giveMeBuilder(Question.class)
+                .set("tag", "right,left,middle,right")
+                .sample();
+        // when
+        // then
+        assertThat(sample.getShuffledTags(3).size()).isEqualTo(3);
+    }
+
+    @Test
+    void 정해진크기보다작은경우_특정크기의태그조회테스트() {
+        // given
+        Question sample = fixtureMonkey.giveMeBuilder(Question.class)
+                .set("tag", "middle,right")
+                .sample();
+        // when
+        // then
+        assertThat(sample.getShuffledTags(3).size()).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/prography/minari/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/prography/minari/question/service/QuestionServiceTest.java
@@ -1,0 +1,10 @@
+package com.prography.minari.question.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class QuestionServiceTest {
+}

--- a/src/test/java/com/prography/minari/question/service/impl/QuestionReaderTest.java
+++ b/src/test/java/com/prography/minari/question/service/impl/QuestionReaderTest.java
@@ -11,6 +11,7 @@ import com.prography.minari.user.entity.User;
 import com.prography.minari.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -77,6 +78,7 @@ class QuestionReaderTest {
     }
 
     @Test
+    @RepeatedTest(5)
     void 데일리_문제조회_테스트() {
         // given
         ArbitraryBuilder<Question> builder = fixtureMonkey.giveMeBuilder(Question.class);

--- a/src/test/java/com/prography/minari/question/service/impl/QuestionReaderTest.java
+++ b/src/test/java/com/prography/minari/question/service/impl/QuestionReaderTest.java
@@ -77,7 +77,6 @@ class QuestionReaderTest {
         );
     }
 
-    @Test
     @RepeatedTest(5)
     void 데일리_문제조회_테스트() {
         // given

--- a/src/test/java/com/prography/minari/question/service/impl/QuestionReaderTest.java
+++ b/src/test/java/com/prography/minari/question/service/impl/QuestionReaderTest.java
@@ -1,9 +1,14 @@
 package com.prography.minari.question.service.impl;
 
+import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.prography.minari.common.entity.Domain;
 import com.prography.minari.question.entity.Question;
 import com.prography.minari.question.repository.QuestionRepository;
+import com.prography.minari.user.entity.PreferDomain;
+import com.prography.minari.user.entity.User;
+import com.prography.minari.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,8 +16,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
@@ -23,6 +36,8 @@ class QuestionReaderTest {
     private QuestionRepository questionRepository;
     @Autowired
     private QuestionReader questionReader;
+    @Autowired
+    private UserRepository userRepository;
 
     @AfterEach
     void init() {
@@ -35,6 +50,7 @@ class QuestionReaderTest {
                 .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
                 .build();
     }
+
     @Test
     void Question엔티티_조회_테스트() {
         // given
@@ -58,5 +74,58 @@ class QuestionReaderTest {
                 () -> assertEquals(saved.getAnswer(), question.getAnswer()),
                 () -> assertEquals(saved.getTag(), question.getTag())
         );
+    }
+
+    @Test
+    void 데일리_문제조회_테스트() {
+        // given
+        ArbitraryBuilder<Question> builder = fixtureMonkey.giveMeBuilder(Question.class);
+
+        List<Question> questions = IntStream.range(0, 5)
+                .mapToObj(i -> {
+                    ArbitraryBuilder<Question> customized = builder
+                            .set("createdDateTime", LocalDateTime.now().plusDays(i));
+                    return customized.sample();
+                })
+                .toList();
+        questionRepository.saveAll(questions);
+        List<Domain> domains = Stream.of(Domain.values())
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toList(),
+                        list -> {
+                            Collections.shuffle(list);
+                            return list.subList(0, Math.min(3, list.size())); // 예: 최대 3개
+                        }
+                ));
+        List<PreferDomain> list = domains.stream().map(domain -> {
+            return PreferDomain.builder()
+                    .name(domain)
+                    .build();
+        }).toList();
+
+        User user = fixtureMonkey.giveMeBuilder(User.class)
+                .set("createdDateTime", LocalDateTime.now())
+                .set("preferDomains",list)
+                .sample();
+        User saveUser = userRepository.save(user);
+
+        // when
+        Optional<Question> question = questionReader.readDaily(saveUser, saveUser.getPreferDomains(), user.getDaysSinceJoined());
+        // then
+
+        Optional<Question> willFindQuestion = question.stream()
+                .filter(q -> user.getPreferDomains().contains(q.getDomain())).min(new Comparator<Question>() {
+                    @Override
+                    public int compare(Question o1, Question o2) {
+                        return Integer.compare(o1.getOrderNum(), o2.getOrderNum());
+                    }
+                });
+
+        if (willFindQuestion.isPresent()) {
+            assertThat(willFindQuestion.get().getOrderNum())
+                    .isEqualTo(question.get().getOrderNum());
+        } else {
+            assertThat(question.isEmpty()).isTrue();
+        }
     }
 }

--- a/src/test/resources/application-default.yml
+++ b/src/test/resources/application-default.yml
@@ -23,7 +23,9 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
-
+jwt:
+  secret: asdasdasadwdwqdasdasdsadassadasdsadasd
+  expiration: 1213123
 naver:
   client:
     id: test


### PR DESCRIPTION
오늘의 미나리 조회기능## #️⃣연관된 이슈
#18 

## 📝작업 내용
- 오늘의 미나리 조회
- 질문에 대한 키워드 조회

## 💬리뷰 요구사항(선택)
- 관심파트를 ENUM으로 해서 일대다로 관리하고 있는데, 어떻게 생각하시나요?
- 키워드는 tag필드에 ","로 이어진 문자열을 파싱하여 쓸 생각입니다! 어떻게 생각하시나요? (운영체제,네트워크 -> ","로 split하여 "운영체제"와 "네트워크"가 키워드가 되는구조)