### PR TITLE
[FEAT(#42)] 유저 회원가입 로직 테스트 코드 작성

### DIFF
--- a/src/main/java/com/prography/minari/social/dto/social/UserInfoDto.java
+++ b/src/main/java/com/prography/minari/social/dto/social/UserInfoDto.java
@@ -1,7 +1,11 @@
 package com.prography.minari.social.dto.social;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.URL;
+
 public record UserInfoDto(
-        Long socialId,
+        @NotNull Long socialId,
         String nickname,
-        String image) {
+        @URL String image) {
 }

--- a/src/main/java/com/prography/minari/user/dto/UserJoinReqDto.java
+++ b/src/main/java/com/prography/minari/user/dto/UserJoinReqDto.java
@@ -3,9 +3,11 @@ package com.prography.minari.user.dto;
 import com.prography.minari.common.entity.Domain;
 import com.prography.minari.user.enums.EmailSendTime;
 import com.prography.minari.user.enums.ExperienceLevel;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 
 public record UserJoinReqDto(
+        @Email String email,
         @NotNull Long userId,
         @NotNull Boolean isSubscribed,
         @NotNull EmailSendTime emailSendTime,

--- a/src/main/java/com/prography/minari/user/entity/User.java
+++ b/src/main/java/com/prography/minari/user/entity/User.java
@@ -71,7 +71,8 @@ public class User extends BaseTimeEntity {
         return user;
     }
 
-    public void join(Boolean isSubscribed, EmailSendTime emailSendTime, ExperienceLevel studyExperienceLevel, ExperienceLevel workExperienceLevel, Domain domain) {
+    public void join(String email, Boolean isSubscribed, EmailSendTime emailSendTime, ExperienceLevel studyExperienceLevel, ExperienceLevel workExperienceLevel, Domain domain) {
+        this.email = email;
         this.isSubscribed = isSubscribed;
         this.emailSendTime = emailSendTime;
         this.studyExperienceLevel = studyExperienceLevel;

--- a/src/main/java/com/prography/minari/user/service/UserService.java
+++ b/src/main/java/com/prography/minari/user/service/UserService.java
@@ -29,6 +29,7 @@ public class UserService {
         // 회원가입
         User joinUser = userWriter.join(
                 findUser,
+                userJoinReqDto.email(),
                 userJoinReqDto.isSubscribed(),
                 userJoinReqDto.emailSendTime(),
                 userJoinReqDto.studyExperienceLevel(),

--- a/src/main/java/com/prography/minari/user/service/impl/UserWriter.java
+++ b/src/main/java/com/prography/minari/user/service/impl/UserWriter.java
@@ -16,8 +16,8 @@ public class UserWriter {
 
     private final UserRepository userRepository;
 
-    public User join(User user, Boolean isSubscribed, EmailSendTime emailSendTime, ExperienceLevel studyExperienceLevel, ExperienceLevel workExperienceLevel, Domain domain) {
-        user.join(isSubscribed, emailSendTime, studyExperienceLevel, workExperienceLevel, domain);
+    public User join(User user, String email, Boolean isSubscribed, EmailSendTime emailSendTime, ExperienceLevel studyExperienceLevel, ExperienceLevel workExperienceLevel, Domain domain) {
+        user.join(email, isSubscribed, emailSendTime, studyExperienceLevel, workExperienceLevel, domain);
         return userRepository.save(user);
     }
 

--- a/src/test/java/com/prography/minari/social/service/SocialServiceTest.java
+++ b/src/test/java/com/prography/minari/social/service/SocialServiceTest.java
@@ -59,11 +59,13 @@ class SocialServiceTest {
                 .orElseGet(() -> userRepository.save(User.create("", KAKAO, userInfoDto.socialId(), userInfoDto.nickname(), userInfoDto.image())));
 
         // then
-        assertEquals(KAKAO, savedUser.getSocialType());
-        assertEquals(userInfoDto.socialId(), savedUser.getSocialId());
-        assertEquals(userInfoDto.nickname(), savedUser.getName());
-        assertEquals(userInfoDto.image(), savedUser.getImage());
-        assertFalse(savedUser.isRegistered());
+        assertAll(
+                () -> assertEquals(KAKAO, savedUser.getSocialType()),
+                () -> assertEquals(userInfoDto.socialId(), savedUser.getSocialId()),
+                () -> assertEquals(userInfoDto.nickname(), savedUser.getName()),
+                () -> assertEquals(userInfoDto.image(), savedUser.getImage()),
+                () -> assertFalse(savedUser.isRegistered())
+        );
         verify(userRepository).save(ArgumentMatchers.<User>any());
 
 
@@ -90,16 +92,18 @@ class SocialServiceTest {
                 .orElseGet(() -> userRepository.save(User.create("", KAKAO, userInfoDto.socialId(), userInfoDto.nickname(), userInfoDto.image())));
 
         // then
-        assertEquals(expectedUser.getEmail(), returnUser.getEmail());
-        assertEquals(expectedUser.getSocialId(), returnUser.getSocialId());
-        assertEquals(expectedUser.getName(), returnUser.getName());
-        assertEquals(expectedUser.getImage(), returnUser.getImage());
-        assertEquals(expectedUser.getEmailSendTime(), returnUser.getEmailSendTime());
-        assertEquals(expectedUser.getStudyExperienceLevel(), returnUser.getStudyExperienceLevel());
-        assertEquals(expectedUser.getWorkExperienceLevel(), returnUser.getWorkExperienceLevel());
-        assertEquals(expectedUser.getDomain(), returnUser.getDomain());
-        assertEquals(expectedUser.isRegistered(), returnUser.isRegistered());
-        assertEquals(expectedUser.isSubscribed(), returnUser.isSubscribed());
+        assertAll(
+                () -> assertEquals(expectedUser.getEmail(), returnUser.getEmail()),
+                () -> assertEquals(expectedUser.getSocialId(), returnUser.getSocialId()),
+                () -> assertEquals(expectedUser.getName(), returnUser.getName()),
+                () -> assertEquals(expectedUser.getImage(), returnUser.getImage()),
+                () -> assertEquals(expectedUser.getEmailSendTime(), returnUser.getEmailSendTime()),
+                () -> assertEquals(expectedUser.getStudyExperienceLevel(), returnUser.getStudyExperienceLevel()),
+                () -> assertEquals(expectedUser.getWorkExperienceLevel(), returnUser.getWorkExperienceLevel()),
+                () -> assertEquals(expectedUser.getDomain(), returnUser.getDomain()),
+                () -> assertEquals(expectedUser.isRegistered(), returnUser.isRegistered()),
+                () -> assertEquals(expectedUser.isSubscribed(), returnUser.isSubscribed())
+        );
         verify(userRepository, never()).save(ArgumentMatchers.<User>any());
     }
 

--- a/src/test/java/com/prography/minari/social/service/SocialServiceTest.java
+++ b/src/test/java/com/prography/minari/social/service/SocialServiceTest.java
@@ -80,7 +80,7 @@ class SocialServiceTest {
                 .sample();
 
         User returnUser = User.create("", KAKAO, userInfoDto.socialId(), userInfoDto.nickname(), userInfoDto.image());
-        returnUser.join(true, AM_08, UNDER_1YEAR, NONE, BACKEND);
+        returnUser.join("minari@gmail.com", true, AM_08, UNDER_1YEAR, NONE, BACKEND);
 
         when(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, userInfoDto.socialId()))
                 .thenReturn(Optional.of(returnUser));

--- a/src/test/java/com/prography/minari/social/service/SocialServiceTest.java
+++ b/src/test/java/com/prography/minari/social/service/SocialServiceTest.java
@@ -1,0 +1,106 @@
+package com.prography.minari.social.service;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.prography.minari.common.entity.Domain;
+import com.prography.minari.common.util.JwtUtil;
+import com.prography.minari.social.dto.enums.SocialType;
+import com.prography.minari.social.dto.social.UserInfoDto;
+import com.prography.minari.user.entity.User;
+import com.prography.minari.user.enums.EmailSendTime;
+import com.prography.minari.user.enums.ExperienceLevel;
+import com.prography.minari.user.repository.UserRepository;
+import org.junit.Before;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.prography.minari.common.entity.Domain.BACKEND;
+import static com.prography.minari.social.dto.enums.SocialType.KAKAO;
+import static com.prography.minari.user.enums.EmailSendTime.AM_08;
+import static com.prography.minari.user.enums.ExperienceLevel.NONE;
+import static com.prography.minari.user.enums.ExperienceLevel.UNDER_1YEAR;
+import static org.hamcrest.Matchers.any;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SocialServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    private static FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .build();
+
+    @Test
+    void 최초_로그인시_User_객체_생성() {
+
+        // given
+        UserInfoDto userInfoDto = fixtureMonkey.giveMeBuilder(UserInfoDto.class)
+                .set("image", "https://picsum.photos/640/640")
+                .sample();
+
+        when(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, userInfoDto.socialId()))
+                .thenReturn(Optional.empty());
+
+        when(userRepository.save(ArgumentMatchers.<User>any()))
+                .thenReturn(User.create("", KAKAO, userInfoDto.socialId(), userInfoDto.nickname(), userInfoDto.image()));
+
+        // when
+        User savedUser = userRepository.findBySocialTypeAndSocialId(KAKAO, userInfoDto.socialId())
+                .orElseGet(() -> userRepository.save(User.create("", KAKAO, userInfoDto.socialId(), userInfoDto.nickname(), userInfoDto.image())));
+
+        // then
+        assertEquals(KAKAO, savedUser.getSocialType());
+        assertEquals(userInfoDto.socialId(), savedUser.getSocialId());
+        assertEquals(userInfoDto.nickname(), savedUser.getName());
+        assertEquals(userInfoDto.image(), savedUser.getImage());
+        assertFalse(savedUser.isRegistered());
+        verify(userRepository).save(ArgumentMatchers.<User>any());
+
+
+    }
+
+    @Test
+    void 기존_회원_로그인시_User_객체_조회() {
+
+        // Kakao API 통신 과정 생략
+
+        // given
+        UserInfoDto userInfoDto = fixtureMonkey.giveMeBuilder(UserInfoDto.class)
+                .set("image", "https://picsum.photos/640/640")
+                .sample();
+
+        User returnUser = User.create("", KAKAO, userInfoDto.socialId(), userInfoDto.nickname(), userInfoDto.image());
+        returnUser.join(true, AM_08, UNDER_1YEAR, NONE, BACKEND);
+
+        when(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, userInfoDto.socialId()))
+                .thenReturn(Optional.of(returnUser));
+
+        // when
+        User expectedUser = userRepository.findBySocialTypeAndSocialId(KAKAO, userInfoDto.socialId())
+                .orElseGet(() -> userRepository.save(User.create("", KAKAO, userInfoDto.socialId(), userInfoDto.nickname(), userInfoDto.image())));
+
+        // then
+        assertEquals(expectedUser.getEmail(), returnUser.getEmail());
+        assertEquals(expectedUser.getSocialId(), returnUser.getSocialId());
+        assertEquals(expectedUser.getName(), returnUser.getName());
+        assertEquals(expectedUser.getImage(), returnUser.getImage());
+        assertEquals(expectedUser.getEmailSendTime(), returnUser.getEmailSendTime());
+        assertEquals(expectedUser.getStudyExperienceLevel(), returnUser.getStudyExperienceLevel());
+        assertEquals(expectedUser.getWorkExperienceLevel(), returnUser.getWorkExperienceLevel());
+        assertEquals(expectedUser.getDomain(), returnUser.getDomain());
+        assertEquals(expectedUser.isRegistered(), returnUser.isRegistered());
+        assertEquals(expectedUser.isSubscribed(), returnUser.isSubscribed());
+        verify(userRepository, never()).save(ArgumentMatchers.<User>any());
+    }
+
+}

--- a/src/test/java/com/prography/minari/user/service/UserServiceTest.java
+++ b/src/test/java/com/prography/minari/user/service/UserServiceTest.java
@@ -1,0 +1,54 @@
+package com.prography.minari.user.service;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.prography.minari.social.dto.social.UserInfoDto;
+import com.prography.minari.user.dto.UserJoinReqDto;
+import com.prography.minari.user.dto.UserJoinResDto;
+import com.prography.minari.user.entity.User;
+import com.prography.minari.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static com.prography.minari.social.dto.enums.SocialType.KAKAO;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class UserServiceTest {
+
+    @Autowired private UserService userService;
+    @Autowired private UserRepository userRepository;
+    private static FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .build();
+
+    @Test
+    void 회원가입() {
+
+        // given
+        UserInfoDto userInfoDto = fixtureMonkey.giveMeBuilder(UserInfoDto.class)
+                .set("image", "https://picsum.photos/640/640")
+                .sample();
+
+        User actualUser = userRepository.save(User.create("", KAKAO, userInfoDto.socialId(), userInfoDto.nickname(), userInfoDto.image()));
+
+        UserJoinReqDto userJoinReqDto = fixtureMonkey.giveMeBuilder(UserJoinReqDto.class)
+                .set("userId", actualUser.getId())
+                .sample();
+
+        // when
+        UserJoinResDto expectedDto = userService.join(userJoinReqDto);
+
+        // then
+        assertNotNull(expectedDto);
+
+        assertEquals(true, expectedDto.isRegistered());
+        assertEquals(userJoinReqDto.emailSendTime(), expectedDto.emailSendTime());
+        assertEquals(userJoinReqDto.studyExperienceLevel(), expectedDto.studyExperienceLevel());
+        assertEquals(userJoinReqDto.workExperienceLevel(), expectedDto.workExperienceLevel());
+        assertEquals(userJoinReqDto.domain(), expectedDto.domain());
+
+    }
+
+}

--- a/src/test/java/com/prography/minari/user/service/UserServiceTest.java
+++ b/src/test/java/com/prography/minari/user/service/UserServiceTest.java
@@ -43,12 +43,13 @@ public class UserServiceTest {
         // then
         assertNotNull(expectedDto);
 
-        assertEquals(true, expectedDto.isRegistered());
-        assertEquals(userJoinReqDto.emailSendTime(), expectedDto.emailSendTime());
-        assertEquals(userJoinReqDto.studyExperienceLevel(), expectedDto.studyExperienceLevel());
-        assertEquals(userJoinReqDto.workExperienceLevel(), expectedDto.workExperienceLevel());
-        assertEquals(userJoinReqDto.domain(), expectedDto.domain());
-
+        assertAll(
+                () -> assertTrue(expectedDto.isRegistered()),
+                () -> assertEquals(userJoinReqDto.emailSendTime(), expectedDto.emailSendTime()),
+                () -> assertEquals(userJoinReqDto.studyExperienceLevel(), expectedDto.studyExperienceLevel()),
+                () -> assertEquals(userJoinReqDto.workExperienceLevel(), expectedDto.workExperienceLevel()),
+                () -> assertEquals(userJoinReqDto.domain(), expectedDto.domain())
+        );
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#42 

## 📝작업 내용

**1. EMAIL 저장 누락 문제 수정**
- 회원가입 과정에서 이메일을 저장하지 않고 있는 문제를 발견하여 수정함.

**2. SocialSerivce 로그인 테스트**
- 최초 로그인시 User 객체 생성하고 있는지 확인
- 기존 회원 로그인시 User 객체 조회하여 처리하고 있는지 확인

**3. UserSerivce 회원가입 테스트**
- 회원가입 시, 데이터 잘 반영되어 저장되는지 확인

## 💬리뷰 요구사항(선택)
- 테스트 코드를 작성해봤는데 어떻게 작성하는게 효율적이고 활용 가능할만한 코드인지 잘 모르겠네요 검토 부탁드립니다!