### PR TITLE
[Refactor(#59)] STT변환시 API지원 포맷으로 형변환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ dependencies {
 	// validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	//ffmpeg
+	implementation("ws.schild:jave-core:3.3.1")
+
 }
 
 tasks.named('test') {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -27,6 +27,9 @@ aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS
 echo "📥 도커 이미지 Pull"
 docker pull $ECR_URI:latest
 
+echo "ffmpeg 도커이미지 pull"
+docker run -it --rm linuxserver/ffmpeg:latest -version
+
 echo "🧼 기존 컨테이너 정리"
 docker stop minari || true
 docker rm minari || true

--- a/src/main/java/com/prography/minari/answer/service/AnswerService.java
+++ b/src/main/java/com/prography/minari/answer/service/AnswerService.java
@@ -6,6 +6,7 @@ import com.prography.minari.answer.service.dto.UserAnswerStatusResponse;
 import com.prography.minari.answer.service.dto.response.InterviewContentResponse;
 import com.prography.minari.answer.service.impl.AnswerReader;
 import com.prography.minari.answer.service.impl.AnswerWriter;
+import com.prography.minari.answer.service.impl.AudioFileFormatConverter;
 import com.prography.minari.answer.service.impl.SttProcessor;
 import com.prography.minari.common.execption.ApiException;
 import com.prography.minari.common.execption.ErrorCode;
@@ -18,6 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Optional;
 
 @Service
@@ -29,12 +32,14 @@ public class AnswerService {
     private final AnswerReader answerReader;
     private final UserReader userReader;
     private final QuestionReader questionReader;
+    private final AudioFileFormatConverter audioFileFormatConverter;
 
     public void writeUserSpeech(MultipartFile file, Long userId, Long questionId) {
         User user = userReader.read(userId);
         Question question = questionReader.read(questionId)
                 .orElseThrow(() -> new ApiException(ErrorCode.QUESTION_NOT_FOUND));
-        String speech = sttProcessor.convertToText(file);
+        byte[] inputStream = audioFileFormatConverter.convertToWavAsByte(file);
+        String speech = sttProcessor.convertToText(inputStream);
         answerWriter.write(Answer.builder()
                 .reply(speech)
                 .user(user)
@@ -54,9 +59,9 @@ public class AnswerService {
 
     public InterviewContentResponse getAnswer(Long questionId, Long userId) {
         Question question = questionReader.read(questionId)
-                .orElseThrow(()->new ApiException(ErrorCode.ENTITY_NOT_FOUND));
+                .orElseThrow(() -> new ApiException(ErrorCode.ENTITY_NOT_FOUND));
         Answer answer = answerReader.readByUserIdAndQuestionId(userId, questionId)
-                .orElseThrow(()->new ApiException(ErrorCode.ENTITY_NOT_FOUND));
+                .orElseThrow(() -> new ApiException(ErrorCode.ENTITY_NOT_FOUND));
         return InterviewContentResponse.of(question.getAnswer(), question.getContent(), answer.getReply());
     }
 }

--- a/src/main/java/com/prography/minari/answer/service/impl/AudioFileFormatConverter.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/AudioFileFormatConverter.java
@@ -24,12 +24,10 @@ public class AudioFileFormatConverter {
     private static final String OUTPUT_DIR = BASE_DIR + "/output/";
 
     public byte[] convertToWavAsByte(MultipartFile file) {
-        // 0. 디렉토리 경로 설정
         File inputDir = new File(INPUT_DIR);
         File outputDir = new File(OUTPUT_DIR);
 
         try {
-            // 1. 디렉토리 존재 확인 및 생성
             if (!inputDir.exists() && !inputDir.mkdirs()) {
                 log.error("입력 디렉토리를 생성할 수 없습니다: {}", inputDir.getAbsolutePath());
                 throw new ApiException(INTERNAL_SERVER_ERROR);
@@ -39,7 +37,6 @@ public class AudioFileFormatConverter {
                 throw new ApiException(INTERNAL_SERVER_ERROR);
             }
 
-            // 2. 파일명 검증 및 설정
             String originalFilename = file.getOriginalFilename();
             if (originalFilename == null || !originalFilename.endsWith(".webm")) {
                 log.warn("지원하지 않는 파일 형식: {}", originalFilename);
@@ -53,11 +50,9 @@ public class AudioFileFormatConverter {
             File inputFile = new File(inputDir, inputFileName);
             File outputFile = new File(outputDir, outputFileName);
 
-            // 3. 업로드 파일 저장
             file.transferTo(inputFile);
             log.info("업로드 파일 저장 완료: {}", inputFile.getAbsolutePath());
 
-            // 4. ffmpeg 명령 실행
             String cmd = String.format(
                     "docker run --rm -v %s:/data linuxserver/ffmpeg:latest -i /data/input/%s /data/output/%s",
                     new File(".").getAbsolutePath(), inputFileName, outputFileName
@@ -82,7 +77,6 @@ public class AudioFileFormatConverter {
                 throw new ApiException(INTERNAL_SERVER_ERROR);
             }
 
-            // 5. 변환된 파일 읽기
             byte[] wavData = Files.readAllBytes(outputFile.toPath());
             log.info("WAV 변환 완료: {} ({} bytes)", outputFile.getName(), wavData.length);
 
@@ -92,11 +86,10 @@ public class AudioFileFormatConverter {
             log.error("I/O 오류 발생: {}", e.getMessage(), e);
             throw new ApiException(INTERNAL_SERVER_ERROR);
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); // 인터럽트 상태 복원
+            Thread.currentThread().interrupt();
             log.error("ffmpeg 프로세스 대기 중 인터럽트 발생", e);
             throw new ApiException(INTERNAL_SERVER_ERROR);
         } finally {
-            // 안전하게 임시 파일 삭제
             Arrays.stream(Objects.requireNonNull(inputDir.listFiles()))
                     .filter(f -> f.getName().endsWith(".webm"))
                     .forEach(f -> {

--- a/src/main/java/com/prography/minari/answer/service/impl/AudioFileFormatConverter.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/AudioFileFormatConverter.java
@@ -1,0 +1,112 @@
+package com.prography.minari.answer.service.impl;
+
+import com.prography.minari.common.aop.ImplService;
+import com.prography.minari.common.execption.ApiException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+
+import static com.prography.minari.common.execption.ErrorCode.AUDIO_UNSUPPORT_FORMAT_EXCEPTION;
+import static com.prography.minari.common.execption.ErrorCode.INTERNAL_SERVER_ERROR;
+
+@Slf4j
+@ImplService
+@RequiredArgsConstructor
+public class AudioFileFormatConverter {
+    private static final String BASE_DIR = System.getProperty("user.dir");
+    private static final String INPUT_DIR = BASE_DIR + "/input/";
+    private static final String OUTPUT_DIR = BASE_DIR + "/output/";
+
+    public byte[] convertToWavAsByte(MultipartFile file) {
+        // 0. 디렉토리 경로 설정
+        File inputDir = new File(INPUT_DIR);
+        File outputDir = new File(OUTPUT_DIR);
+
+        try {
+            // 1. 디렉토리 존재 확인 및 생성
+            if (!inputDir.exists() && !inputDir.mkdirs()) {
+                log.error("입력 디렉토리를 생성할 수 없습니다: {}", inputDir.getAbsolutePath());
+                throw new ApiException(INTERNAL_SERVER_ERROR);
+            }
+            if (!outputDir.exists() && !outputDir.mkdirs()) {
+                log.error("출력 디렉토리를 생성할 수 없습니다: {}", outputDir.getAbsolutePath());
+                throw new ApiException(INTERNAL_SERVER_ERROR);
+            }
+
+            // 2. 파일명 검증 및 설정
+            String originalFilename = file.getOriginalFilename();
+            if (originalFilename == null || !originalFilename.endsWith(".webm")) {
+                log.warn("지원하지 않는 파일 형식: {}", originalFilename);
+                throw new ApiException(AUDIO_UNSUPPORT_FORMAT_EXCEPTION);
+            }
+
+            String baseName = UUID.randomUUID().toString();
+            String inputFileName = baseName + ".webm";
+            String outputFileName = baseName + ".wav";
+
+            File inputFile = new File(inputDir, inputFileName);
+            File outputFile = new File(outputDir, outputFileName);
+
+            // 3. 업로드 파일 저장
+            file.transferTo(inputFile);
+            log.info("업로드 파일 저장 완료: {}", inputFile.getAbsolutePath());
+
+            // 4. ffmpeg 명령 실행
+            String cmd = String.format(
+                    "docker run --rm -v %s:/data linuxserver/ffmpeg:latest -i /data/input/%s /data/output/%s",
+                    new File(".").getAbsolutePath(), inputFileName, outputFileName
+            );
+
+            log.debug("실행할 ffmpeg 명령어: {}", cmd);
+
+            ProcessBuilder pb = new ProcessBuilder("bash", "-c", cmd);
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
+
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    log.debug("ffmpeg >> {}", line);
+                }
+            }
+
+            int exitCode = process.waitFor();
+            if (exitCode != 0 || !outputFile.exists()) {
+                log.error("ffmpeg 변환 실패 - exitCode: {}, 파일 존재 여부: {}", exitCode, outputFile.exists());
+                throw new ApiException(INTERNAL_SERVER_ERROR);
+            }
+
+            // 5. 변환된 파일 읽기
+            byte[] wavData = Files.readAllBytes(outputFile.toPath());
+            log.info("WAV 변환 완료: {} ({} bytes)", outputFile.getName(), wavData.length);
+
+            return wavData;
+
+        } catch (IOException e) {
+            log.error("I/O 오류 발생: {}", e.getMessage(), e);
+            throw new ApiException(INTERNAL_SERVER_ERROR);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt(); // 인터럽트 상태 복원
+            log.error("ffmpeg 프로세스 대기 중 인터럽트 발생", e);
+            throw new ApiException(INTERNAL_SERVER_ERROR);
+        } finally {
+            // 안전하게 임시 파일 삭제
+            Arrays.stream(Objects.requireNonNull(inputDir.listFiles()))
+                    .filter(f -> f.getName().endsWith(".webm"))
+                    .forEach(f -> {
+                        if (f.delete()) log.debug("입력 파일 삭제 완료: {}", f.getName());
+                    });
+            Arrays.stream(Objects.requireNonNull(outputDir.listFiles()))
+                    .filter(f -> f.getName().endsWith(".wav"))
+                    .forEach(f -> {
+                        if (f.delete()) log.debug("출력 파일 삭제 완료: {}", f.getName());
+                    });
+        }
+    }
+}

--- a/src/main/java/com/prography/minari/answer/service/impl/NaverApiClient.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/NaverApiClient.java
@@ -2,12 +2,14 @@ package com.prography.minari.answer.service.impl;
 
 
 import com.prography.minari.answer.service.dto.SttResponseDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.client.WebClient;
 
+@Slf4j
 @Component
 public class NaverApiClient implements SttApiClient {
     private WebClient webClient;
@@ -27,6 +29,7 @@ public class NaverApiClient implements SttApiClient {
     @Override
     public String convertToText(byte[] voiceFile) {
         try {
+            log.info("Converting text to Naver");
             SttResponseDto.Naver block = webClient.post()
                     .uri(uriBuilder -> uriBuilder
                             .path("/recog/v1/stt")

--- a/src/main/java/com/prography/minari/answer/service/impl/SttProcessor.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/SttProcessor.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 public class SttProcessor {
     private final SttApiClient sttApiClient;
 
-    public String convertToText(MultipartFile file) {
+    public String convertToText(byte[] file) {
         AudioFormat format = getAudioFormat(file);
         List<byte[]> rawChunks = splitWavToExactMinutes(file, format);
         List<String> texts = rawChunks.stream()
@@ -41,59 +41,68 @@ public class SttProcessor {
 
     }
 
-    private AudioFormat getAudioFormat(MultipartFile file) {
-        try (InputStream is = new BufferedInputStream(file.getInputStream());
-             AudioInputStream fullStream = AudioSystem.getAudioInputStream(is)) {
+    private AudioFormat getAudioFormat(byte[] wavData) {
+        log.info("파일형식 조회");
+        try (AudioInputStream fullStream = AudioSystem.getAudioInputStream(new BufferedInputStream(new ByteArrayInputStream(wavData)))) {
             return fullStream.getFormat();
         } catch (UnsupportedAudioFileException e) {
-            log.error("지원하지 않는 오디오 포맷: {}",e.getMessage());
+            log.error("지원하지 않는 오디오 포맷: {}", e.getMessage());
             throw new ApiException(ErrorCode.AUDIO_UNSUPPORT_FORMAT_EXCEPTION);
         } catch (IOException e) {
-            log.error("오디오 파일 처리 중 IO 오류 발생: {}",e.getMessage());
+            log.error("오디오 파일 처리 중 IO 오류 발생: {}", e.getMessage());
             throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 
-    private List<byte[]> splitWavToExactMinutes(MultipartFile file, AudioFormat format) {
-        try (InputStream is = new BufferedInputStream(file.getInputStream());
-             AudioInputStream fullStream = AudioSystem.getAudioInputStream(is)) {
+    private List<byte[]> splitWavToExactMinutes(byte[] file, AudioFormat format) {
+        try (AudioInputStream fullStream = AudioSystem.getAudioInputStream(
+                new BufferedInputStream(new ByteArrayInputStream(file)))) {
 
-            float frameRate = format.getFrameRate();     // ex: 44100.0
-            int frameSize = format.getFrameSize();       // ex: 4 (16bit stereo)
+            float frameRate = format.getFrameRate();     // 예: 44100.0
+            int frameSize = format.getFrameSize();       // 예: 4 (16bit stereo)
+            int bytesPerMinute = (int) (frameRate * frameSize * 60); // 1분 분량
 
-            int bytesPerMinute = (int) (frameRate * frameSize * 60); // 정확히 1분 분량
+            log.info("오디오 분할 시작 - frameRate: {}, frameSize: {}, bytesPerMinute: {}, 총 파일 크기: {} bytes",
+                    frameRate, frameSize, bytesPerMinute, file.length);
+
             List<byte[]> chunks = new ArrayList<>();
-
             byte[] buffer = new byte[bytesPerMinute];
             int offset = 0;
 
             int bytesRead;
+            int chunkCount = 0;
+
             while ((bytesRead = fullStream.read(buffer, offset, buffer.length - offset)) != -1) {
                 offset += bytesRead;
 
                 // 1분 분량이 꽉 찼을 때만 추가
                 if (offset == buffer.length) {
                     chunks.add(Arrays.copyOf(buffer, buffer.length));
+                    log.debug("1분 청크 분리 완료: {} bytes (chunk #{})", buffer.length, ++chunkCount);
                     offset = 0;
                 }
             }
 
-            // 마지막 덜 찬 chunk도 추가
+            // 남은 데이터도 마지막 청크로 추가
             if (offset > 0) {
                 chunks.add(Arrays.copyOf(buffer, offset));
+                log.debug("마지막 청크 분리 완료: {} bytes (chunk #{})", offset, ++chunkCount);
             }
 
+            log.info("오디오 분할 완료 - 총 청크 수: {}", chunks.size());
             return chunks;
-        }catch (UnsupportedAudioFileException e) {
-            log.error("지원하지 않는 오디오 포맷: {}",e.getMessage());
+
+        } catch (UnsupportedAudioFileException e) {
+            log.error("지원하지 않는 오디오 포맷: {}", e.getMessage(), e);
             throw new ApiException(ErrorCode.AUDIO_UNSUPPORT_FORMAT_EXCEPTION);
         } catch (IOException e) {
-            log.error("오디오 파일 처리 중 IO 오류 발생: {}",e.getMessage());
+            log.error("오디오 파일 처리 중 IO 오류 발생: {}", e.getMessage(), e);
             throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 
     private byte[] toAutioFormatBytes(byte[] rawData, AudioFormat format) throws IOException {
+        log.info("오디오 형식({}) 추가",format);
         try (
                 ByteArrayInputStream bais = new ByteArrayInputStream(rawData);
                 ByteArrayOutputStream baos = new ByteArrayOutputStream()

--- a/src/main/java/com/prography/minari/answer/service/impl/SttProcessor.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/SttProcessor.java
@@ -58,9 +58,9 @@ public class SttProcessor {
         try (AudioInputStream fullStream = AudioSystem.getAudioInputStream(
                 new BufferedInputStream(new ByteArrayInputStream(file)))) {
 
-            float frameRate = format.getFrameRate();     // 예: 44100.0
-            int frameSize = format.getFrameSize();       // 예: 4 (16bit stereo)
-            int bytesPerMinute = (int) (frameRate * frameSize * 60); // 1분 분량
+            float frameRate = format.getFrameRate();
+            int frameSize = format.getFrameSize();
+            int bytesPerMinute = (int) (frameRate * frameSize * 60);
 
             log.info("오디오 분할 시작 - frameRate: {}, frameSize: {}, bytesPerMinute: {}, 총 파일 크기: {} bytes",
                     frameRate, frameSize, bytesPerMinute, file.length);
@@ -75,7 +75,6 @@ public class SttProcessor {
             while ((bytesRead = fullStream.read(buffer, offset, buffer.length - offset)) != -1) {
                 offset += bytesRead;
 
-                // 1분 분량이 꽉 찼을 때만 추가
                 if (offset == buffer.length) {
                     chunks.add(Arrays.copyOf(buffer, buffer.length));
                     log.debug("1분 청크 분리 완료: {} bytes (chunk #{})", buffer.length, ++chunkCount);
@@ -83,7 +82,6 @@ public class SttProcessor {
                 }
             }
 
-            // 남은 데이터도 마지막 청크로 추가
             if (offset > 0) {
                 chunks.add(Arrays.copyOf(buffer, offset));
                 log.debug("마지막 청크 분리 완료: {} bytes (chunk #{})", offset, ++chunkCount);


### PR DESCRIPTION
## #️⃣연관된 이슈
#3  #59 

## 📝작업 내용
- 오디오 형변환 구현체 추가(AudioFileFormatConverter)
   - FFMPEG를 이용하여 브라우저 지원 오디오 포맷(webm)을 STT API의 지원포맷(wav)로 변환하는 로직추가
- STT로직
   - 사용자조회 -> 문제조회 -> 오디오 형변환 -> STT호출 -> 답변 저장


## 💬리뷰 요구사항(선택)
- 현재는 EC2에서 바로 도커(ffmpeg)를 호출해서 형변환이 진행됩니다. 메인 기능인데 서버에서 도커를 직접 호출하고 오디오파일을 임시저장하는 형태가 맞는것인지 조금 고민이네요..! (서버부하 + 리소스낭비)
- 이후에는 sqs+lambda형태로 구조를 빼야할지 아니면 다른 좋은 방법이 있을지 궁금합니다.(지금이 최선인것일수도 있어요..!)