### PR TITLE
[Fix(#59)] 스프링 도커 파일에 docker cli설치 커맨드 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 FROM eclipse-temurin:21-jdk
+
+# docker CLI 설치
+RUN apt-get update && \
+    apt-get install -y docker.io && \
+    apt-get clean
+
 VOLUME /tmp
+
+# JAR 복사
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
+
+# Spring Boot 실행
 ENTRYPOINT ["sh", "-c", "java -jar /app.jar --spring.profiles.active=live"]


### PR DESCRIPTION
## #️⃣연관된 이슈
#59

## 📝작업 내용
- 스프링 도커 파일에 docker cli설치 커맨드 추가