### PR TITLE
[Fix(#59)] ffmpeg 호스트 파일 못읽는 원인 추적을 위해 음성파일 삭제 로직 제외

### DIFF
--- a/src/main/java/com/prography/minari/answer/service/impl/AudioFileFormatConverter.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/AudioFileFormatConverter.java
@@ -93,8 +93,8 @@ public class AudioFileFormatConverter {
             log.error("ffmpeg 프로세스 대기 중 인터럽트 발생", e);
             throw new ApiException(INTERNAL_SERVER_ERROR);
         } finally {
-            deleteTempFiles(inputDir, ".webm");
-            deleteTempFiles(outputDir, ".wav");
+            /*deleteTempFiles(inputDir, ".webm");
+            deleteTempFiles(outputDir, ".wav");*/
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#59 

## 📝작업 내용
-  ffmpeg 호스트 파일 못읽는 원인 추적을 위해 음성파일 삭제 로직 제외