### PR TITLE
[Fix(#69)] 면접답변 저장시 success누락 수정

### DIFF
--- a/src/main/java/com/prography/minari/answer/entity/Answer.java
+++ b/src/main/java/com/prography/minari/answer/entity/Answer.java
@@ -17,7 +17,7 @@ public class Answer extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false,name = "reply")
+    @Column(name = "reply",length = 1000)
     private String reply;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/prography/minari/answer/service/AnswerService.java
+++ b/src/main/java/com/prography/minari/answer/service/AnswerService.java
@@ -35,16 +35,29 @@ public class AnswerService {
     private final AudioFileFormatConverter audioFileFormatConverter;
 
     public void writeUserSpeech(MultipartFile file, Long userId, Long questionId) {
-        User user = userReader.read(userId);
-        Question question = questionReader.read(questionId)
-                .orElseThrow(() -> new ApiException(ErrorCode.QUESTION_NOT_FOUND));
-        byte[] inputStream = audioFileFormatConverter.convertToWavAsByte(file);
-        String speech = sttProcessor.convertToText(inputStream);
-        answerWriter.write(Answer.builder()
-                .reply(speech)
-                .user(user)
-                .question(question)
-                .build());
+        String speech = null;
+        User user = null;
+        Question question = null;
+        boolean success = true;
+
+        try {
+            byte[] inputStream = audioFileFormatConverter.convertToWavAsByte(file);
+            speech = sttProcessor.convertToText(inputStream);
+            user = userReader.read(userId);
+            question = questionReader.read(questionId)
+                    .orElseThrow(() -> new ApiException(ErrorCode.QUESTION_NOT_FOUND));
+        } catch (ApiException e) {
+            success = false;
+            throw e;
+        } finally {
+            // 예외가 발생하든 말든 항상 기록
+            answerWriter.write(Answer.builder()
+                    .reply(speech)
+                    .user(user)
+                    .question(question)
+                    .success(success)
+                    .build());
+        }
     }
 
     public UserAnswerStatusResponse getSttProcessStatus(Long userId, Long questionId) {

--- a/src/main/java/com/prography/minari/answer/service/AnswerService.java
+++ b/src/main/java/com/prography/minari/answer/service/AnswerService.java
@@ -35,17 +35,19 @@ public class AnswerService {
     private final AudioFileFormatConverter audioFileFormatConverter;
 
     public void writeUserSpeech(MultipartFile file, Long userId, Long questionId) {
-        String speech = null;
-        User user = null;
-        Question question = null;
-        boolean success = true;
+        User user = userReader.read(userId);
+        Question question = questionReader.read(questionId)
+                .orElseThrow(() -> new ApiException(ErrorCode.QUESTION_NOT_FOUND));
 
+        boolean success = true;
+        String speech = null;
         try {
+            long l = System.currentTimeMillis();
             byte[] inputStream = audioFileFormatConverter.convertToWavAsByte(file);
+            System.out.println(System.currentTimeMillis() - l);
+            l = System.currentTimeMillis();
             speech = sttProcessor.convertToText(inputStream);
-            user = userReader.read(userId);
-            question = questionReader.read(questionId)
-                    .orElseThrow(() -> new ApiException(ErrorCode.QUESTION_NOT_FOUND));
+            System.out.println(System.currentTimeMillis() - l);
         } catch (ApiException e) {
             success = false;
             throw e;

--- a/src/main/java/com/prography/minari/answer/service/impl/NaverApiClient.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/NaverApiClient.java
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 @Slf4j
 @Component
@@ -25,6 +26,21 @@ public class NaverApiClient implements SttApiClient {
                 .build();
     }
 
+    @Override
+    public Mono<String> convertToTextNonBlock(byte[] voiceFile) {
+        return webClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/recog/v1/stt")
+                        .queryParam("lang", "Kor")
+                        .build())
+                .header("X-NCP-APIGW-API-KEY-ID", clientId)
+                .header("X-NCP-APIGW-API-KEY", clientSecret)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .bodyValue(voiceFile)
+                .retrieve()
+                .bodyToMono(SttResponseDto.Naver.class)
+                .map(SttResponseDto.Naver::getText);
+    }
 
     @Override
     public String convertToText(byte[] voiceFile) {

--- a/src/main/java/com/prography/minari/answer/service/impl/SttApiClient.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/SttApiClient.java
@@ -1,7 +1,9 @@
 package com.prography.minari.answer.service.impl;
 
 import org.springframework.web.multipart.MultipartFile;
+import reactor.core.publisher.Mono;
 
 public interface SttApiClient {
-    String convertToText(byte[] file);
+    String convertToText(byte[] file); // 동기용
+    Mono<String> convertToTextNonBlock(byte[] file); // WebClient 전용
 }

--- a/src/main/java/com/prography/minari/answer/service/impl/SttProcessor.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/SttProcessor.java
@@ -6,6 +6,8 @@ import com.prography.minari.common.execption.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.multipart.MultipartFile;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import javax.sound.sampled.*;
 import java.io.*;
@@ -23,22 +25,21 @@ public class SttProcessor {
     public String convertToText(byte[] file) {
         AudioFormat format = getAudioFormat(file);
         List<byte[]> rawChunks = splitWavToExactMinutes(file, format);
-        List<String> texts = rawChunks.stream()
-                .map(chunk -> {
+        List<String> texts = Flux.fromIterable(rawChunks)
+                .flatMapSequential(chunk -> {
                     try {
                         byte[] wavChunk = toAutioFormatBytes(chunk, format);
-                        return sttApiClient.convertToText(wavChunk);
+                        return sttApiClient.convertToTextNonBlock(wavChunk); // Mono<String>
                     } catch (Exception e) {
-                        throw new RuntimeException(e);
+                        return Mono.error(e);
                     }
                 })
-                .toList();
-
-        return texts.stream()
                 .filter(s -> !s.isBlank())
                 .map(s -> s.endsWith(".") ? s : s + ".")
-                .collect(Collectors.joining(" "));
+                .collectList()
+                .block();
 
+        return String.join(" ", texts);
     }
 
     private AudioFormat getAudioFormat(byte[] wavData) {


### PR DESCRIPTION
## #️⃣연관된 이슈
#3 #69 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
- 예외 터졌을때와 정상실행시 success 구분하여 저장되도록 수정


## 💬리뷰 요구사항(선택)
- #77 을 먼저 merge부탁드립니다!
- 실패시에도 Answer DB에 데이터를 넣는다는게 맞는지에 대한 고민이 계속드네요! 
- 실패후 재시도에서 success가 false인 애를 update를 해줘야할지. 이후에 Answer를 사용할때 불필요 데이터가 섞여있다는것때문에 괜히 필터링이 들어가는것도 우려되고 상현님은 면접 프로세스 로직을 어떻게 하는게 최선이라 생각하시는지 궁금합니다!