### PR TITLE
[Perf(#69)] api호출시 non-blocking방식으로 개선

### DIFF
--- a/src/main/java/com/prography/minari/answer/entity/Answer.java
+++ b/src/main/java/com/prography/minari/answer/entity/Answer.java
@@ -17,7 +17,7 @@ public class Answer extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false,name = "reply")
+    @Column(name = "reply",length = 1000)
     private String reply;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/prography/minari/answer/service/AnswerService.java
+++ b/src/main/java/com/prography/minari/answer/service/AnswerService.java
@@ -35,17 +35,19 @@ public class AnswerService {
     private final AudioFileFormatConverter audioFileFormatConverter;
 
     public void writeUserSpeech(MultipartFile file, Long userId, Long questionId) {
-        String speech = null;
-        User user = null;
-        Question question = null;
-        boolean success = true;
+        User user = userReader.read(userId);
+        Question question = questionReader.read(questionId)
+                .orElseThrow(() -> new ApiException(ErrorCode.QUESTION_NOT_FOUND));
 
+        boolean success = true;
+        String speech = null;
         try {
+            long l = System.currentTimeMillis();
             byte[] inputStream = audioFileFormatConverter.convertToWavAsByte(file);
+            System.out.println(System.currentTimeMillis() - l);
+            l = System.currentTimeMillis();
             speech = sttProcessor.convertToText(inputStream);
-            user = userReader.read(userId);
-            question = questionReader.read(questionId)
-                    .orElseThrow(() -> new ApiException(ErrorCode.QUESTION_NOT_FOUND));
+            System.out.println(System.currentTimeMillis() - l);
         } catch (ApiException e) {
             success = false;
             throw e;

--- a/src/main/java/com/prography/minari/answer/service/impl/NaverApiClient.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/NaverApiClient.java
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 @Slf4j
 @Component
@@ -25,6 +26,21 @@ public class NaverApiClient implements SttApiClient {
                 .build();
     }
 
+    @Override
+    public Mono<String> convertToTextNonBlock(byte[] voiceFile) {
+        return webClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/recog/v1/stt")
+                        .queryParam("lang", "Kor")
+                        .build())
+                .header("X-NCP-APIGW-API-KEY-ID", clientId)
+                .header("X-NCP-APIGW-API-KEY", clientSecret)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .bodyValue(voiceFile)
+                .retrieve()
+                .bodyToMono(SttResponseDto.Naver.class)
+                .map(SttResponseDto.Naver::getText);
+    }
 
     @Override
     public String convertToText(byte[] voiceFile) {

--- a/src/main/java/com/prography/minari/answer/service/impl/SttApiClient.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/SttApiClient.java
@@ -1,7 +1,9 @@
 package com.prography.minari.answer.service.impl;
 
 import org.springframework.web.multipart.MultipartFile;
+import reactor.core.publisher.Mono;
 
 public interface SttApiClient {
-    String convertToText(byte[] file);
+    String convertToText(byte[] file); // 동기용
+    Mono<String> convertToTextNonBlock(byte[] file); // WebClient 전용
 }

--- a/src/main/java/com/prography/minari/answer/service/impl/SttProcessor.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/SttProcessor.java
@@ -6,6 +6,8 @@ import com.prography.minari.common.execption.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.multipart.MultipartFile;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import javax.sound.sampled.*;
 import java.io.*;
@@ -23,22 +25,21 @@ public class SttProcessor {
     public String convertToText(byte[] file) {
         AudioFormat format = getAudioFormat(file);
         List<byte[]> rawChunks = splitWavToExactMinutes(file, format);
-        List<String> texts = rawChunks.stream()
-                .map(chunk -> {
+        List<String> texts = Flux.fromIterable(rawChunks)
+                .flatMapSequential(chunk -> {
                     try {
                         byte[] wavChunk = toAutioFormatBytes(chunk, format);
-                        return sttApiClient.convertToText(wavChunk);
+                        return sttApiClient.convertToTextNonBlock(wavChunk); // Mono<String>
                     } catch (Exception e) {
-                        throw new RuntimeException(e);
+                        return Mono.error(e);
                     }
                 })
-                .toList();
-
-        return texts.stream()
                 .filter(s -> !s.isBlank())
                 .map(s -> s.endsWith(".") ? s : s + ".")
-                .collect(Collectors.joining(" "));
+                .collectList()
+                .block();
 
+        return String.join(" ", texts);
     }
 
     private AudioFormat getAudioFormat(byte[] wavData) {


### PR DESCRIPTION
## #️⃣연관된 이슈
#69 

## 📝작업 내용
- reply의 길이 1000자로 증가
- 최대 5개의 파일을 동기식으로 api호출이 아닌 non-blocking식으로 호출하여 하나의 스레드로 여러 작업 처리가능하도록 개선 (100초->20초)

## 💬리뷰 요구사항(선택)
- #78 을 먼저 merge부탁드립니다.
- non-blocking을 처음 적용해보아서 처리시 우려되는 부분있을까요? 상현님의 생각이 궁금합니다!!