### PR TITLE
[feat (#94)] 어드민 씨앗누락 CS대응 api

### DIFF
--- a/src/main/java/com/prography/minari/admin/controller/AdminPaymentController.java
+++ b/src/main/java/com/prography/minari/admin/controller/AdminPaymentController.java
@@ -1,0 +1,25 @@
+package com.prography.minari.admin.controller;
+
+import com.prography.minari.admin.controller.dto.RewardForceRequest;
+import com.prography.minari.admin.service.AdminRewardService;
+import com.prography.minari.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("/admin/api")
+@RequiredArgsConstructor
+public class AdminPaymentController {
+    private final AdminRewardService adminRewardService;
+
+    @PostMapping("/v1/payment/force")
+    public CommonResponse<String> forceCharge(@RequestBody RewardForceRequest request) {
+        adminRewardService.giveSeedForce(request.getUserUUID(),
+                request.getSeeds(),
+                request.getRole(),
+                request.getReason(),
+                request.getMemo());
+        return CommonResponse.ok();
+    }
+}

--- a/src/main/java/com/prography/minari/admin/controller/dto/RewardForceRequest.java
+++ b/src/main/java/com/prography/minari/admin/controller/dto/RewardForceRequest.java
@@ -1,0 +1,12 @@
+package com.prography.minari.admin.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RewardForceRequest {
+    private String userUUID;
+    private int seeds;
+    private String role;
+    private String reason;
+    private String memo;
+}

--- a/src/main/java/com/prography/minari/admin/service/AdminRewardService.java
+++ b/src/main/java/com/prography/minari/admin/service/AdminRewardService.java
@@ -1,0 +1,33 @@
+package com.prography.minari.admin.service;
+
+import com.prography.minari.payment.entity.PaymentLog;
+import com.prography.minari.payment.entity.Seed;
+import com.prography.minari.payment.service.impl.PaymentWriter;
+import com.prography.minari.payment.service.impl.SeedReader;
+import com.prography.minari.payment.service.impl.SeedWriter;
+import com.prography.minari.user.entity.User;
+import com.prography.minari.user.service.impl.UserReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminRewardService {
+    private final UserReader userReader;
+    private final SeedReader seedReader;
+    private final SeedWriter seedWriter;
+    private final PaymentWriter paymentWriter;
+
+    public void giveSeedForce(String userUUID, int seeds, String role, String reason, String memo) {
+        User user = userReader.readByUUID(userUUID);
+        Seed seed = seedReader.readByUserId(user.getId()).orElse(new Seed(0L,user));
+        seedWriter.write(seed);
+        seed.charge(seeds);
+        paymentWriter.write(PaymentLog.builder()
+                .userId(user.getId())
+                .memo(memo)
+                .reason(reason)
+                .role(role)
+                .build());
+    }
+}

--- a/src/main/java/com/prography/minari/payment/entity/PaymentLog.java
+++ b/src/main/java/com/prography/minari/payment/entity/PaymentLog.java
@@ -1,0 +1,21 @@
+package com.prography.minari.payment.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "LOG_PAYMENT")
+public class PaymentLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String memo;
+    private Long userId;
+    private String reason;
+    private String role;
+}

--- a/src/main/java/com/prography/minari/payment/entity/Seed.java
+++ b/src/main/java/com/prography/minari/payment/entity/Seed.java
@@ -1,0 +1,28 @@
+package com.prography.minari.payment.entity;
+
+import com.prography.minari.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Table(name = "SEEDS")
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class Seed {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long total;
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+    public void charge(long amount) {
+        total += amount;
+    }
+
+    public Seed(Long total, User user) {
+        this.total = total;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/prography/minari/payment/repository/PaymentLogRepository.java
+++ b/src/main/java/com/prography/minari/payment/repository/PaymentLogRepository.java
@@ -1,0 +1,9 @@
+package com.prography.minari.payment.repository;
+
+import com.prography.minari.payment.entity.PaymentLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PaymentLogRepository extends JpaRepository<PaymentLog, Long> {
+}

--- a/src/main/java/com/prography/minari/payment/repository/SeedRepository.java
+++ b/src/main/java/com/prography/minari/payment/repository/SeedRepository.java
@@ -1,0 +1,16 @@
+package com.prography.minari.payment.repository;
+
+import com.prography.minari.payment.entity.Seed;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SeedRepository extends JpaRepository<Seed, Long> {
+    @Query("select s from Seed s where s.user.id=:userId")
+    Optional<Seed> findByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/prography/minari/payment/service/impl/PaymentWriter.java
+++ b/src/main/java/com/prography/minari/payment/service/impl/PaymentWriter.java
@@ -1,0 +1,18 @@
+package com.prography.minari.payment.service.impl;
+
+import com.prography.minari.common.aop.ImplService;
+import com.prography.minari.payment.entity.PaymentLog;
+import com.prography.minari.payment.repository.PaymentLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@ImplService
+@RequiredArgsConstructor
+@Transactional
+public class PaymentWriter {
+    private final PaymentLogRepository paymentLogRepository;
+    public PaymentLog write(PaymentLog paymentLog) {
+        return paymentLogRepository.save(paymentLog);
+    }
+}

--- a/src/main/java/com/prography/minari/payment/service/impl/SeedReader.java
+++ b/src/main/java/com/prography/minari/payment/service/impl/SeedReader.java
@@ -1,0 +1,20 @@
+package com.prography.minari.payment.service.impl;
+
+import com.prography.minari.common.aop.ImplService;
+import com.prography.minari.payment.entity.Seed;
+import com.prography.minari.payment.repository.SeedRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@ImplService
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SeedReader {
+    private final SeedRepository seedRepository;
+
+    public Optional<Seed> readByUserId(Long userId) {
+        return seedRepository.findByUserId(userId);
+    }
+}

--- a/src/main/java/com/prography/minari/payment/service/impl/SeedWriter.java
+++ b/src/main/java/com/prography/minari/payment/service/impl/SeedWriter.java
@@ -1,0 +1,18 @@
+package com.prography.minari.payment.service.impl;
+
+import com.prography.minari.common.aop.ImplService;
+import com.prography.minari.payment.entity.Seed;
+import com.prography.minari.payment.repository.SeedRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@ImplService
+@RequiredArgsConstructor
+@Transactional
+public class SeedWriter {
+    private final SeedRepository seedRepository;
+
+    public Seed write(Seed seed) {
+        return seedRepository.save(seed);
+    }
+}

--- a/src/main/java/com/prography/minari/user/entity/User.java
+++ b/src/main/java/com/prography/minari/user/entity/User.java
@@ -57,6 +57,9 @@ public class User extends BaseTimeEntity {
     @Enumerated(value = STRING)
     private Domain domain;
 
+    @Column(name = "uuid")
+    private String uuid;
+
     public static User create(String email, SocialType socialType, Long socialId, String name, String image) {
         User user = new User();
         user.email = email;

--- a/src/main/java/com/prography/minari/user/repository/UserRepository.java
+++ b/src/main/java/com/prography/minari/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findBySocialTypeAndSocialId(SocialType socialType, Long socialId);
+
+    Optional<User> findByUuid(String uuid);
 }

--- a/src/main/java/com/prography/minari/user/service/impl/UserReader.java
+++ b/src/main/java/com/prography/minari/user/service/impl/UserReader.java
@@ -15,4 +15,8 @@ public class UserReader {
     public User read(Long userId) {
         return userRepository.findById(userId).orElseThrow(()->new RuntimeException("User not found"));
     }
+
+    public User readByUUID(String uuid) {
+        return userRepository.findByUuid(uuid).orElseThrow(() -> new RuntimeException("User not found"));
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#94 

## 📝작업 내용
- 임의로 어드민에서 사용자에게 씨앗 넣어줄수 있는 기능

## 💬리뷰 요구사항(선택)
- 메일용 배치, 어드민, 서비스 등 같은 레이어의 다른 성격의 엔드포인트가 생기면서 멀티모듈 진행하는 것도 괜찮아보이네요! 귀찮긴하지만 상현님의 생각은 어떠신가요?
- 씨앗을 업데이트하는 코드에서 동시성 문제가 발생하진 않을까 걱정되긴하네요. 물론 어드민이니까 그럴가능성은 적지만 미리 예방하는것도 좋으니까요! 첫번재 결제관련 코드인만큼 걱정되는 것들이 무엇이 있을까요??