### PR TITLE
[FEAT(#81)] 문제가 없을 시, 예외처리

### DIFF
--- a/src/main/java/com/prography/minari/common/execption/ErrorCode.java
+++ b/src/main/java/com/prography/minari/common/execption/ErrorCode.java
@@ -11,7 +11,7 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.","C003"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다.","C004"),
     ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 회원가입이 완료된 사용자입니다.","C005"),
-    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "데이터를 찾을 수 없습니다.","Q001"),
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "남아있는 문제가 존재하지 않습니다.","Q001"),
     JWT_EXPIRED_EXCEPTION(HttpStatus.NOT_FOUND, "토큰이 만료되었습니다.","JWT001"),
     JWT_INVALID_SIGNATURE_EXCEPTION(HttpStatus.NOT_FOUND, "유효하지 않은 서명입니다.","JWT002"),
     JWT_UNSUPPORT_FORMAT_EXCEPTION(HttpStatus.NOT_FOUND, "지원하지 않는 JWT 포맷입니다.","JWT003"),

--- a/src/main/java/com/prography/minari/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/prography/minari/common/handler/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.prography.minari.common.handler;
 import com.prography.minari.common.execption.ApiException;
 import com.prography.minari.common.execption.ErrorCode;
 import com.prography.minari.common.response.CommonResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -12,12 +13,14 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ApiException.class)
     public ResponseEntity handleApiException(ApiException e) {
+        log.info(e.getErrorMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(CommonResponse.fail(e.getErrorCode(), null));
+                .body(CommonResponse.fail(e.getErrorCode(), e.getErrorMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/prography/minari/question/service/impl/QuestionReader.java
+++ b/src/main/java/com/prography/minari/question/service/impl/QuestionReader.java
@@ -23,8 +23,9 @@ public class QuestionReader {
     }
 
     public Optional<Question> readDaily(User user, List<Domain> domains, long day) {
-        return Optional.ofNullable(
-                questionRepository.findDailyUnsolvedQuestionByDomains(user.getId(), domains, PageRequest.of((int) day, 1))
-                .getContent().getFirst());
+        return questionRepository
+                .findDailyUnsolvedQuestionByDomains(user.getId(), domains, PageRequest.of((int) day, 1))
+                .getContent().stream().findFirst();
     }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#81 

## 📝작업 내용

### 📄 ErrorCode
- `message` 수정
```java
// QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "데이터를 찾을 수 없습니다.","Q001"),
QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "남아있는 문제가 존재하지 않습니다.","Q001"),
```

### 📄 GlobalExceptionHandler
- 로그 추가
- 응답값에 `message` 추가
```java
@Slf4j
public class GlobalExceptionHandler {

    @ExceptionHandler(ApiException.class)
    public ResponseEntity handleApiException(ApiException e) {
        log.info(e.getErrorMessage());
        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                // .body(CommonResponse.fail(e.getErrorCode(), null));
                .body(CommonResponse.fail(e.getErrorCode(), e.getErrorMessage()));
    }
```

### 📄 QuestionReader
- `NoSuchElementException` 방지를 위한 stream
```java
    public Optional<Question> readDaily(User user, List<Domain> domains, long day) {
        // return Optional.ofNullable(
        //         questionRepository.findDailyUnsolvedQuestionByDomains(user.getId(), domains, PageRequest.of((int) day, 1))
        //         .getContent().getFirst());
        return questionRepository
                .findDailyUnsolvedQuestionByDomains(user.getId(), domains, PageRequest.of((int) day, 1))
                .getContent().stream().findFirst();
    }
```

## 💬리뷰 요구사항(선택)