### PR TITLE
[FEAT(#108)] 계정 휴면 상태 해제 API

### DIFF
--- a/src/main/java/com/prography/minari/common/execption/ErrorCode.java
+++ b/src/main/java/com/prography/minari/common/execption/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다.","C004"),
     ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 회원가입이 완료된 사용자입니다.","C005"),
     ACCOUNT_SOFT_DELETED(HttpStatus.CONFLICT, "계정 삭제된 사용자입니다.","C006"),
+    ACCOUNT_NOT_DELETED(HttpStatus.CONFLICT, "계정 삭제되지 않은 사용자입니다.","C007"),
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "남아있는 문제가 존재하지 않습니다.","Q001"),
     JWT_EXPIRED_EXCEPTION(HttpStatus.NOT_FOUND, "토큰이 만료되었습니다.","JWT001"),
     JWT_INVALID_SIGNATURE_EXCEPTION(HttpStatus.NOT_FOUND, "유효하지 않은 서명입니다.","JWT002"),

--- a/src/main/java/com/prography/minari/user/controller/UserController.java
+++ b/src/main/java/com/prography/minari/user/controller/UserController.java
@@ -91,9 +91,9 @@ public class UserController implements UserApiDocs {
                 .body(CommonResponse.success("로그아웃되었습니다."));
     }
 
-    @PostMapping("/users/reactivate")
-    public ResponseEntity<CommonResponse<String>> reactivate(@AuthenticationPrincipal User user) {
-        userService.reactivate(user);
+    @PostMapping("/users/activate")
+    public ResponseEntity<CommonResponse<String>> activate(@AuthenticationPrincipal User user) {
+        userService.activate(user);
         return ResponseEntity.ok(CommonResponse.success("계정 휴면 상태 해제"));
     }
 

--- a/src/main/java/com/prography/minari/user/controller/UserController.java
+++ b/src/main/java/com/prography/minari/user/controller/UserController.java
@@ -91,4 +91,10 @@ public class UserController implements UserApiDocs {
                 .body(CommonResponse.success("로그아웃되었습니다."));
     }
 
+    @PostMapping("/users/reactivate")
+    public ResponseEntity<CommonResponse<String>> reactivate(@AuthenticationPrincipal User user) {
+        userService.reactivate(user);
+        return ResponseEntity.ok(CommonResponse.success("계정 휴면 상태 해제"));
+    }
+
 }

--- a/src/main/java/com/prography/minari/user/controller/docs/UserApiDocs.java
+++ b/src/main/java/com/prography/minari/user/controller/docs/UserApiDocs.java
@@ -131,8 +131,8 @@ public interface UserApiDocs {
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 실패")
     })
-    @PostMapping("/users/reactivate")
-    ResponseEntity<CommonResponse<String>> reactivate(
+    @PostMapping("/users/activate")
+    ResponseEntity<CommonResponse<String>> activate(
             @Parameter(hidden = true) @AuthenticationPrincipal User user
     );
 

--- a/src/main/java/com/prography/minari/user/controller/docs/UserApiDocs.java
+++ b/src/main/java/com/prography/minari/user/controller/docs/UserApiDocs.java
@@ -121,4 +121,19 @@ public interface UserApiDocs {
     ResponseEntity<CommonResponse<String>> logout(
             @Parameter(hidden = true) @AuthenticationPrincipal User user
     );
+
+    @Operation(
+            summary = "계정 휴면 상태 해제",
+            description = "로그인된 사용자의 계정이 휴면 상태인 경우, 이를 해제합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "휴면 해제 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @PostMapping("/users/reactivate")
+    ResponseEntity<CommonResponse<String>> reactivate(
+            @Parameter(hidden = true) @AuthenticationPrincipal User user
+    );
+
 }

--- a/src/main/java/com/prography/minari/user/entity/User.java
+++ b/src/main/java/com/prography/minari/user/entity/User.java
@@ -117,7 +117,7 @@ public class User extends BaseTimeEntity {
         this.deletedAt = LocalDateTime.now().plusDays(7);
     }
 
-    public void reactivate() {
+    public void activate() {
 
         if(!this.isDeleted) throw new ApiException(ACCOUNT_NOT_DELETED);
 

--- a/src/main/java/com/prography/minari/user/entity/User.java
+++ b/src/main/java/com/prography/minari/user/entity/User.java
@@ -3,12 +3,12 @@ package com.prography.minari.user.entity;
 import com.prography.minari.answer.entity.Answer;
 import com.prography.minari.common.entity.BaseTimeEntity;
 import com.prography.minari.common.entity.Domain;
+import com.prography.minari.common.execption.ApiException;
 import com.prography.minari.payment.entity.Seed;
 import com.prography.minari.social.dto.enums.SocialType;
 import com.prography.minari.user.enums.EmailSendTime;
 import com.prography.minari.user.enums.ExperienceLevel;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +20,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.prography.minari.common.execption.ErrorCode.ACCOUNT_NOT_DELETED;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 
@@ -117,6 +118,9 @@ public class User extends BaseTimeEntity {
     }
 
     public void reactivate() {
+
+        if(!this.isDeleted) throw new ApiException(ACCOUNT_NOT_DELETED);
+
         this.isDeleted = false;
         this.deletedAt = null;
     }

--- a/src/main/java/com/prography/minari/user/entity/User.java
+++ b/src/main/java/com/prography/minari/user/entity/User.java
@@ -116,4 +116,8 @@ public class User extends BaseTimeEntity {
         this.deletedAt = LocalDateTime.now().plusDays(7);
     }
 
+    public void reactivate() {
+        this.isDeleted = false;
+        this.deletedAt = null;
+    }
 }

--- a/src/main/java/com/prography/minari/user/service/UserService.java
+++ b/src/main/java/com/prography/minari/user/service/UserService.java
@@ -66,4 +66,8 @@ public class UserService {
     public void logout(User user) {
         redisProcessor.deleteValue(user.getId().toString());
     }
+
+    public void reactivate(User user) {
+        userWriter.reactivate(user);
+    }
 }

--- a/src/main/java/com/prography/minari/user/service/UserService.java
+++ b/src/main/java/com/prography/minari/user/service/UserService.java
@@ -67,7 +67,7 @@ public class UserService {
         redisProcessor.deleteValue(user.getId().toString());
     }
 
-    public void reactivate(User user) {
-        userWriter.reactivate(user);
+    public void activate(User user) {
+        userWriter.activate(user);
     }
 }

--- a/src/main/java/com/prography/minari/user/service/impl/UserWriter.java
+++ b/src/main/java/com/prography/minari/user/service/impl/UserWriter.java
@@ -40,4 +40,9 @@ public class UserWriter {
         mailAuthLogRepository.deleteByUserId(userId);
         userRepository.deleteById(userId);
     }
+
+    public void reactivate(User user) {
+        user.reactivate();
+        userRepository.save(user);
+    }
 }

--- a/src/main/java/com/prography/minari/user/service/impl/UserWriter.java
+++ b/src/main/java/com/prography/minari/user/service/impl/UserWriter.java
@@ -41,8 +41,8 @@ public class UserWriter {
         userRepository.deleteById(userId);
     }
 
-    public void reactivate(User user) {
-        user.reactivate();
+    public void activate(User user) {
+        user.activate();
         userRepository.save(user);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#108 

## 📝작업 내용

### UserController.java
```java
    @PostMapping("/users/reactivate")
    public ResponseEntity<CommonResponse<String>> reactivate(@AuthenticationPrincipal User user) {
        userService.reactivate(user);
        return ResponseEntity.ok(CommonResponse.success("계정 휴면 상태 해제"));
    }
```

### UserApiDocs.java
```java
    @Operation(
            summary = "계정 휴면 상태 해제",
            description = "로그인된 사용자의 계정이 휴면 상태인 경우, 이를 해제합니다."
    )
    @ApiResponses(value = {
            @ApiResponse(responseCode = "200", description = "휴면 해제 성공",
                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
            @ApiResponse(responseCode = "401", description = "인증 실패")
    })
    @PostMapping("/users/reactivate")
    ResponseEntity<CommonResponse<String>> reactivate(
            @Parameter(hidden = true) @AuthenticationPrincipal User user
    );
```

### UserService.java
```java
    public void reactivate(User user) {
        userWriter.reactivate(user);
    }
```

### UserWriter.java
```java
    public void reactivate(User user) {
        user.reactivate();
        userRepository.save(user);
    }
```

### User.java
```java
    public void reactivate() {
        this.isDeleted = false;
        this.deletedAt = null;
    }
```

## 💬리뷰 요구사항(선택)
- 사용자(`User`)의 삭제(`isDeleted`) 정보만 수정해주는 간단한 API입니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint allowing users to reactivate their dormant or inactive accounts.
  * Users receive a confirmation message upon successful reactivation of their account.

* **Documentation**
  * Updated API documentation to include details about the new account reactivation endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->