### PR TITLE
[Feat(#121)] 크레딧에 보유시 면접 추가진행 가능 로직 추가

### DIFF
--- a/src/main/java/com/prography/minari/answer/service/AnswerService.java
+++ b/src/main/java/com/prography/minari/answer/service/AnswerService.java
@@ -17,6 +17,8 @@ import com.prography.minari.common.execption.ApiException;
 import com.prography.minari.common.execption.ErrorCode;
 import com.prography.minari.common.util.AnalyticsUtil;
 import com.prography.minari.payment.service.impl.CreditCounter;
+import com.prography.minari.payment.service.impl.CreditUsageTarget;
+import com.prography.minari.payment.service.impl.CreditUseProcessor;
 import com.prography.minari.question.entity.Question;
 import com.prography.minari.question.service.impl.QuestionReader;
 import com.prography.minari.user.entity.User;
@@ -48,32 +50,50 @@ public class AnswerService {
     private final FileUploader fileUploader;
     private final AudioFileFormatConverter audioFileFormatConverter;
     private final CreditCounter creditCounter;
+    private final CreditUseProcessor creditUseProcessor;
 
     /**
      * Processes a user's uploaded speech audio file for a specific question, converts it to text, saves the answer, and uploads the audio file.
-     *
+     * <p>
      * Retrieves the user and question, checks for existing answers to prevent duplicates, converts the audio to WAV format, performs speech-to-text processing, saves the resulting answer, uploads the original audio file to storage, and returns a response containing answer details.
      *
-     * @param file      the uploaded audio file containing the user's speech
-     * @param userId    the ID of the user submitting the answer
+     * @param file       the uploaded audio file containing the user's speech
+     * @param userId     the ID of the user submitting the answer
      * @param questionId the ID of the question being answered
-     * @param memo      an optional memo to associate with the answer
+     * @param memo       an optional memo to associate with the answer
      * @return an InterviewContentResponse containing the answer's details, including running time, question content, reply, and creation date
      * @throws ApiException if the question is not found or if an answer already exists for the user and question
      */
     public InterviewContentResponse writeUserSpeech(MultipartFile file, Long userId, Long questionId, String memo) {
+        final long INTEGERVIEW_COST = 1L;
+
         User user = userReader.read(userId);
         Question question = questionReader.read(questionId)
                 .orElseThrow(() -> new ApiException(ErrorCode.QUESTION_NOT_FOUND));
         List<Answer> answers = answerReader.readAllByUserIdAndQuestionId(userId, questionId);
-
+        Long leftCredit = creditCounter.countNotUsedCredit(user.getId());
         /**
          * Todo
          * 프론트 개발 완료후 주석 제거
-         */
+         *//*
         if (!answers.isEmpty()) {
             throw new ApiException(ErrorCode.FREE_ANSWER_ALREADY_DONE);
+        }*/
+
+        // 무료안했다면 스킵
+
+        if (!answers.isEmpty()) {
+            if (leftCredit > 0) {
+                // 돈 차감로직
+                creditUseProcessor.use(userId, INTEGERVIEW_COST, CreditUsageTarget.INTERVIEW);
+            } else {
+                throw new ApiException(ErrorCode.FREE_ANSWER_ALREADY_DONE);
+            }
         }
+        // 무료 한경우
+        // 돈이 있다면 돈 차감
+        // 돈이 없다면 돈 차감
+
 
         byte[] inputStream = audioFileFormatConverter.convertToWavAsByte(file);
         SttConvertAudioFileInfo convertResult = sttProcessor.convertToText(inputStream);
@@ -92,7 +112,9 @@ public class AnswerService {
                         .minusSeconds(Math.round(convertResult.getRunningTime()))
                         .toLocalDate())
                 .build());
-        fileUploader.upload(file, "/voice");
+
+        // 배포누락으로 잠시 주석
+//        fileUploader.upload(file, "/voice");
         return InterviewContentResponse.builder()
                 .runningTime(convertResult.getRunningTime())
                 .answer(question.getAnswer())

--- a/src/main/java/com/prography/minari/answer/service/impl/AudioFileFormatConverter.java
+++ b/src/main/java/com/prography/minari/answer/service/impl/AudioFileFormatConverter.java
@@ -125,7 +125,7 @@ public class AudioFileFormatConverter {
     }
 
     private boolean isLocalProfile() {
-        return "local".equalsIgnoreCase(activeProfile);
+        return "local".equalsIgnoreCase(activeProfile)||"ssh".equalsIgnoreCase(activeProfile);
     }
 
     private boolean isLiveProfile() {

--- a/src/main/java/com/prography/minari/payment/entity/Credit.java
+++ b/src/main/java/com/prography/minari/payment/entity/Credit.java
@@ -22,6 +22,7 @@ public class Credit extends BaseTimeEntity {
     private Long userId; // 사용자 번호
     private Long paymentId; // 결제 번호
     private Long productId; // 구매한 상품번호
+    @Enumerated(EnumType.STRING)
     private CreditStatus status; // 사용, 환불
 
     public boolean isRefund(){

--- a/src/main/java/com/prography/minari/payment/entity/CreditUsage.java
+++ b/src/main/java/com/prography/minari/payment/entity/CreditUsage.java
@@ -1,6 +1,7 @@
 package com.prography.minari.payment.entity;
 
 import com.prography.minari.common.entity.BaseTimeEntity;
+import com.prography.minari.payment.service.impl.CreditUsageTarget;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,5 +24,6 @@ public class CreditUsage extends BaseTimeEntity {
     private Credit credit;
 
     private Long usedAmount;
-    private Long usedTarget;//어디에 사용했는지
+    @Enumerated(EnumType.STRING)
+    private CreditUsageTarget usedTarget; //어디에 사용했는지
 }

--- a/src/main/java/com/prography/minari/payment/service/impl/CreditUsageTarget.java
+++ b/src/main/java/com/prography/minari/payment/service/impl/CreditUsageTarget.java
@@ -1,0 +1,11 @@
+package com.prography.minari.payment.service.impl;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CreditUsageTarget {
+    INTERVIEW("면접진행");
+    private String description;
+}

--- a/src/main/java/com/prography/minari/payment/service/impl/CreditUseProcessor.java
+++ b/src/main/java/com/prography/minari/payment/service/impl/CreditUseProcessor.java
@@ -1,0 +1,71 @@
+package com.prography.minari.payment.service.impl;
+
+import com.prography.minari.common.aop.ImplService;
+import com.prography.minari.common.entity.BaseTimeEntity;
+import com.prography.minari.payment.entity.Credit;
+import com.prography.minari.payment.entity.CreditUsage;
+import com.prography.minari.payment.repository.CreditJpaRepository;
+import com.prography.minari.payment.repository.CreditUsageJpaRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.*;
+
+import static com.prography.minari.payment.service.impl.CreditUsageTarget.INTERVIEW;
+
+@ImplService
+@RequiredArgsConstructor
+public class CreditUseProcessor {
+    private final CreditJpaRepository creditJpaRepository;
+    private final CreditUsageJpaRepository creditUsageJpaRepository;
+
+    public void use(Long userId, Long used, CreditUsageTarget target) {
+        List<Credit> credits = creditJpaRepository.findAllByUserId(userId).stream()
+                .sorted(Comparator.comparing(BaseTimeEntity::getCreatedDateTime,Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
+
+        List<Long> creditIds = credits.stream()
+                .map(Credit::getId)
+                .toList();
+
+        List<CreditUsage> creditUsages = creditUsageJpaRepository.findAllByCreditIdIn(creditIds);
+
+        Map<Long, Long> usages = new HashMap<>();
+        for (CreditUsage creditUsage : creditUsages) {
+            Long creditId = creditUsage.getCredit().getId();
+            usages.put(creditId, usages.getOrDefault(creditId, 0L) + creditUsage.getUsedAmount());
+        }
+
+        List<CreditUsage> usedList = new ArrayList<>();
+        for (Credit credit : credits) {
+            if (used <= 0) break;
+
+            Long initAmount = credit.getAmount();
+            Long usedCreditAmount = usages.getOrDefault(credit.getId(), 0L);
+            Long remaining = initAmount - usedCreditAmount;
+
+            if (remaining <= 0) continue;
+
+            if (remaining >= used) {
+                usedList.add(CreditUsage.builder()
+                        .credit(credit)
+                        .usedTarget(target)
+                        .usedAmount(used)
+                        .build());
+                used = 0L;
+            } else {
+                usedList.add(CreditUsage.builder()
+                        .credit(credit)
+                        .usedTarget(target)
+                        .usedAmount(remaining)
+                        .build());
+                used -= remaining;
+            }
+        }
+
+        if (used > 0) {
+            throw new IllegalStateException("사용 가능한 크레딧이 부족합니다.");
+        }
+
+        creditUsageJpaRepository.saveAll(usedList);
+    }
+}

--- a/src/test/java/com/prography/minari/payment/service/impl/CreditUseProcessorTest.java
+++ b/src/test/java/com/prography/minari/payment/service/impl/CreditUseProcessorTest.java
@@ -1,0 +1,105 @@
+package com.prography.minari.payment.service.impl;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.prography.minari.payment.entity.Credit;
+import com.prography.minari.payment.entity.CreditUsage;
+import com.prography.minari.payment.repository.CreditJpaRepository;
+import com.prography.minari.payment.repository.CreditUsageJpaRepository;
+import com.prography.minari.payment.service.CreditService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.prography.minari.payment.service.impl.CreditUsageTarget.INTERVIEW;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CreditUseProcessorTest {
+    @InjectMocks
+    private CreditUseProcessor creditUseProcessor;
+
+    @Mock
+    private CreditJpaRepository creditJpaRepository;
+
+    @Mock
+    private CreditUsageJpaRepository creditUsageJpaRepository;
+
+    private FixtureMonkey fixtureMonkey;
+
+    @BeforeEach
+    void setUp() {
+        fixtureMonkey = FixtureMonkey.builder()
+                .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+                .build();
+    }
+
+    @Test
+    void 크레딧을_순차적으로_사용() {
+        // given
+        Long userId = 1L;
+        Long totalUsedAmount = 180L;
+
+        // Credit 3개 생성 (100, 50, 200)
+        Credit credit1 = fixtureMonkey.giveMeBuilder(Credit.class)
+                .set("id", 1L)
+                .set("userId", userId)
+                .set("amount", 100L)
+                .set("createdDateTime", LocalDateTime.now().minusDays(2))
+                .sample();
+
+        Credit credit2 = fixtureMonkey.giveMeBuilder(Credit.class)
+                .set("id", 2L)
+                .set("userId", userId)
+                .set("amount", 50L)
+                .set("createdDateTime", LocalDateTime.now().minusDays(1))
+                .sample();
+
+        Credit credit3 = fixtureMonkey.giveMeBuilder(Credit.class)
+                .set("id", 3L)
+                .set("userId", userId)
+                .set("amount", 200L)
+                .set("createdDateTime", LocalDateTime.now())
+                .sample();
+
+        List<Credit> credits = List.of(credit1, credit2, credit3);
+
+        when(creditJpaRepository.findAllByUserId(userId)).thenReturn(credits);
+        when(creditUsageJpaRepository.findAllByCreditIdIn(List.of(1L, 2L, 3L)))
+                .thenReturn(List.of());
+
+        ArgumentCaptor<List<CreditUsage>> captor = ArgumentCaptor.forClass(List.class);
+
+        // when
+        creditUseProcessor.use(userId, totalUsedAmount, INTERVIEW);
+
+        // then
+        verify(creditUsageJpaRepository).saveAll(captor.capture());
+        List<CreditUsage> result = captor.getValue();
+
+        assertAll(
+                () -> assertThat(result).hasSize(3),
+                () -> assertThat(result.get(0).getCredit().getId()).isEqualTo(1L),
+                () -> assertThat(result.get(0).getUsedAmount()).isEqualTo(100L),
+
+                () -> assertThat(result.get(1).getCredit().getId()).isEqualTo(2L),
+                () -> assertThat(result.get(1).getUsedAmount()).isEqualTo(50L),
+
+                () -> assertThat(result.get(2).getCredit().getId()).isEqualTo(3L),
+                () -> assertThat(result.get(2).getUsedAmount()).isEqualTo(30L)
+        );
+
+
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#121 

## 📝작업 내용
- 크레딧 보유시 재시도 로직 추가

### 재시도 로직
1. answer의 존재여부로 무료제공 여부 확인
2. 크레딧이 있다면 다음 로직 진행
3. 크레딧 없다면 예외처리
```
if (!answers.isEmpty()) {
            if (leftCredit > 0) {
                // 돈 차감로직
                creditUseProcessor.use(userId, INTEGERVIEW_COST, CreditUsageTarget.INTERVIEW);
            } else {
                throw new ApiException(ErrorCode.FREE_ANSWER_ALREADY_DONE);
            }
        }
```


### CreditUseProcessor
- 전체 credit을 조회한후 가장 오래전 크레딧부터 사용내역을 조회하여 사용할수 있다면 차감하는 방식으로 진행됩니다.

```
for (Credit credit : credits) {
            if (used <= 0) break;

            Long initAmount = credit.getAmount();
            Long usedCreditAmount = usages.getOrDefault(credit.getId(), 0L);
            Long remaining = initAmount - usedCreditAmount;

            if (remaining <= 0) continue;

            if (remaining >= used) {
                usedList.add(CreditUsage.builder()
                        .credit(credit)
                        .usedTarget(target)
                        .usedAmount(used)
                        .build());
                used = 0L;
            } else {
                usedList.add(CreditUsage.builder()
                        .credit(credit)
                        .usedTarget(target)
                        .usedAmount(remaining)
                        .build());
                used -= remaining;
            }
        }

```

## 💬리뷰 요구사항(선택)
- 급하니까 코드를 막 쓰게되네요... 이후에 리팩토링 하면 좋겠어요..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced credit deduction when submitting multiple answers to a question, with credits required for additional submissions.
  * Added new enum for credit usage targets and improved handling of credit usage types.
  * Implemented a processor to manage sequential credit usage across multiple credits.

* **Bug Fixes**
  * Improved profile detection to support both "local" and "ssh" environments.

* **Refactor**
  * Changed credit usage target from a numeric type to a descriptive enum for clarity.
  * Updated credit status persistence to store string values in the database.

* **Tests**
  * Added tests to verify correct sequential deduction of credits during usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->