### PR TITLE
[Feat(#131)] 면접진행시 씨앗지급 이벤트 로직 추가

### DIFF
--- a/src/main/java/com/prography/minari/answer/service/AnswerService.java
+++ b/src/main/java/com/prography/minari/answer/service/AnswerService.java
@@ -16,9 +16,7 @@ import com.prography.minari.aws.impl.FileUploader;
 import com.prography.minari.common.execption.ApiException;
 import com.prography.minari.common.execption.ErrorCode;
 import com.prography.minari.common.util.AnalyticsUtil;
-import com.prography.minari.payment.service.impl.CreditCounter;
-import com.prography.minari.payment.service.impl.CreditUsageTarget;
-import com.prography.minari.payment.service.impl.CreditUseProcessor;
+import com.prography.minari.payment.service.impl.*;
 import com.prography.minari.question.entity.Question;
 import com.prography.minari.question.service.impl.QuestionReader;
 import com.prography.minari.user.entity.User;
@@ -49,6 +47,7 @@ public class AnswerService {
     private final AudioFileFormatConverter audioFileFormatConverter;
     private final CreditCounter creditCounter;
     private final CreditUseProcessor creditUseProcessor;
+    private final EventExecutor eventExecutor;
 
     /**
      * Processes a user's uploaded speech audio file for a specific question, converts it to text, saves the answer, and uploads the audio file.
@@ -113,6 +112,8 @@ public class AnswerService {
 
         // 배포누락으로 잠시 주석
 //        fileUploader.upload(file, "/voice");
+        eventExecutor.trigger(EventTrigger.DAILY_INTERVIEW_EVENT, user);
+
         return InterviewContentResponse.builder()
                 .runningTime(convertResult.getRunningTime())
                 .answer(question.getAnswer())

--- a/src/main/java/com/prography/minari/batch/item/processor/ExpiredCreditStatusChangeProcessor.java
+++ b/src/main/java/com/prography/minari/batch/item/processor/ExpiredCreditStatusChangeProcessor.java
@@ -1,0 +1,21 @@
+package com.prography.minari.batch.item.processor;
+
+import com.prography.minari.payment.entity.Credit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExpiredCreditStatusChangeProcessor {
+
+    public ItemProcessor<Credit, Credit> processor() {
+        return credit -> {
+            log.info("Expired credit status: {}", credit.getStatus());
+            credit.changeStatusOfExpiredCredit();
+            return credit;
+        };
+    }
+}

--- a/src/main/java/com/prography/minari/batch/item/processor/MailContentCreateProcessor.java
+++ b/src/main/java/com/prography/minari/batch/item/processor/MailContentCreateProcessor.java
@@ -8,10 +8,9 @@ import com.prography.minari.question.service.impl.QuestionReader;
 import com.prography.minari.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.ItemProcessor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
-import java.util.HashMap;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -22,7 +21,6 @@ public class MailContentCreateProcessor {
     private final MailTemplateCreater mailTemplateCreater;
     private final QuestionReader questionReader;
 
-    @Bean
     public ItemProcessor<User, MailRequest> processor() {
         return user -> {
 
@@ -34,7 +32,8 @@ public class MailContentCreateProcessor {
 
             return questionOpt.map(question ->
                     mailTemplateCreater.create(
-                            "오늘의 미나리",
+                            String.format("%d월 %d일 오늘의 미나리가 도착했어요!",
+                                    LocalDate.now().getMonthValue(), LocalDate.now().getDayOfMonth()),
                             user.getEmail(),
                             Map.of("category", question.getDomain().toString(), "keyword", question.getTags().getFirst()),
                             "today-minari")

--- a/src/main/java/com/prography/minari/batch/item/reader/CreditItemReader.java
+++ b/src/main/java/com/prography/minari/batch/item/reader/CreditItemReader.java
@@ -1,0 +1,50 @@
+package com.prography.minari.batch.item.reader;
+
+import com.prography.minari.payment.entity.Credit;
+import com.prography.minari.payment.entity.CreditStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.Order;
+import org.springframework.batch.item.database.support.PostgresPagingQueryProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class CreditItemReader {
+
+    @Bean
+    public JdbcPagingItemReader<Credit> readExpiredCredit(DataSource dataSource) throws Exception {
+        JdbcPagingItemReader<Credit> reader = new JdbcPagingItemReader<>();
+
+        reader.setDataSource(dataSource);
+        reader.setPageSize(100);
+
+        // Query provider 설정
+        PostgresPagingQueryProvider queryProvider = new PostgresPagingQueryProvider();
+        queryProvider.setSelectClause("SELECT *");
+        queryProvider.setFromClause("FROM credit");
+        queryProvider.setWhereClause("expired_date_time::date = CURRENT_DATE");
+        queryProvider.setSortKeys(Map.of("id", Order.ASCENDING)); // 정렬 필수
+
+        reader.setQueryProvider(queryProvider);
+
+        // RowMapper 설정
+        reader.setRowMapper((rs, rowNum) -> Credit.builder()
+                .id(rs.getLong("id"))
+                .expiredDateTime(rs.getTimestamp("expired_date_time").toLocalDateTime())
+                .userId(rs.getLong("user_id"))
+                .paymentId(rs.getLong("payment_id"))
+                .amount(rs.getLong("amount"))
+                .productId(rs.getLong("product_id"))
+                .status(CreditStatus.valueOf(rs.getString("status")))
+                .build());
+
+        reader.afterPropertiesSet();
+
+        return reader;
+    }
+}

--- a/src/main/java/com/prography/minari/batch/item/writer/CreditItemWriter.java
+++ b/src/main/java/com/prography/minari/batch/item/writer/CreditItemWriter.java
@@ -1,0 +1,17 @@
+package com.prography.minari.batch.item.writer;
+
+import com.prography.minari.payment.entity.Credit;
+import com.prography.minari.payment.repository.CreditJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CreditItemWriter{
+    private final CreditJpaRepository creditRepository;
+
+    public ItemWriter<Credit> write(){
+        return creditRepository::saveAll;
+    }
+}

--- a/src/main/java/com/prography/minari/batch/job/CreditJobConfiguration.java
+++ b/src/main/java/com/prography/minari/batch/job/CreditJobConfiguration.java
@@ -1,0 +1,24 @@
+package com.prography.minari.batch.job;
+
+import com.prography.minari.batch.step.UserCreditRemoveStep;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+
+@Component
+@RequiredArgsConstructor
+public class CreditJobConfiguration {
+    private final UserCreditRemoveStep userCreditRemoveStep;
+    @Bean
+    public Job remove(JobRepository jobRepository, PlatformTransactionManager transactionManager, DataSource dataSource) throws Exception {
+        return new JobBuilder("remove-expired-credit", jobRepository)
+                .start(userCreditRemoveStep.changeStatusOfExpiredCredit(jobRepository, transactionManager,dataSource))
+                .build();
+    }
+}

--- a/src/main/java/com/prography/minari/batch/jobLauncher/CreditRemoveLauncher.java
+++ b/src/main/java/com/prography/minari/batch/jobLauncher/CreditRemoveLauncher.java
@@ -1,0 +1,50 @@
+package com.prography.minari.batch.jobLauncher;
+
+import com.prography.minari.batch.job.CreditJobConfiguration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CreditRemoveLauncher {
+    private final JobLauncher jobLauncher;
+    private final CreditJobConfiguration creditJobConfiguration;
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final DataSource dataSource;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void launch() throws Exception {
+        log.info("[{}] Starting change expired credit status job", LocalDateTime.now());
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addLocalDate("changeStatusOfExpiredCredit", LocalDate.now())
+                    .toJobParameters();
+
+            jobLauncher.run(creditJobConfiguration.remove(jobRepository, transactionManager,dataSource), params);
+            log.info("[{}] Finished change expired credit status job", LocalDateTime.now());
+        } catch (JobInstanceAlreadyCompleteException e) {
+            log.info("expired credit Job already completed: {}", e.getMessage());
+        } catch (JobExecutionAlreadyRunningException |
+                 JobRestartException |
+                 JobParametersInvalidException e) {
+            log.error("expired credit Job failed to start", e);
+        }
+    }
+}

--- a/src/main/java/com/prography/minari/batch/jobLauncher/MailSendLauncher.java
+++ b/src/main/java/com/prography/minari/batch/jobLauncher/MailSendLauncher.java
@@ -2,16 +2,23 @@ package com.prography.minari.batch.jobLauncher;
 
 import com.prography.minari.batch.job.MailJobConfiguration;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersInvalidException;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.JobRestartException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MailSendLauncher {
@@ -22,9 +29,21 @@ public class MailSendLauncher {
 
     @Scheduled(cron = "0 0 8 * * *")
     public void launch() throws Exception {
-        JobParameters mailSendDateParameter = new JobParametersBuilder()
-                .addLocalDateTime("sendMailDate", LocalDateTime.now())
-                .toJobParameters();
-        jobLauncher.run(mailJobConfiguration.start(jobRepository, transactionManager), mailSendDateParameter);
+        log.info("[{}] Starting mail send job",LocalDateTime.now());
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addLocalDate("sendMailDate", LocalDate.now())
+                    .toJobParameters();
+
+            jobLauncher.run(mailJobConfiguration.start(jobRepository, transactionManager), params);
+        } catch (JobInstanceAlreadyCompleteException e) {
+            log.info("Job already completed: {}", e.getMessage());
+        } catch (JobExecutionAlreadyRunningException |
+                 JobRestartException |
+                 JobParametersInvalidException e) {
+            log.error("Job failed to start", e);
+        }finally {
+            log.info("[{}] Finished mail send job",LocalDateTime.now());
+        }
     }
 }

--- a/src/main/java/com/prography/minari/batch/step/UserCreditRemoveStep.java
+++ b/src/main/java/com/prography/minari/batch/step/UserCreditRemoveStep.java
@@ -1,0 +1,33 @@
+package com.prography.minari.batch.step;
+
+import com.prography.minari.batch.item.processor.ExpiredCreditStatusChangeProcessor;
+import com.prography.minari.batch.item.reader.CreditItemReader;
+import com.prography.minari.batch.item.writer.CreditItemWriter;
+import com.prography.minari.payment.entity.Credit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+
+@Component
+@RequiredArgsConstructor
+public class UserCreditRemoveStep {
+    private final CreditItemReader creditItemReader;
+    private final CreditItemWriter creditItemWriter;
+    private final ExpiredCreditStatusChangeProcessor expiredCreditStatusChangeProcessor;
+
+    public Step changeStatusOfExpiredCredit(JobRepository jobRepository,
+                               PlatformTransactionManager transactionManager,
+                                            DataSource dataSource) throws Exception {
+        return new StepBuilder("changeStatusOfExpiredCredit", jobRepository)
+                .<Credit, Credit>chunk(100, transactionManager)
+                .reader(creditItemReader.readExpiredCredit(dataSource))
+                .processor(expiredCreditStatusChangeProcessor.processor())
+                .writer(creditItemWriter.write())
+                .build();
+    }
+}

--- a/src/main/java/com/prography/minari/common/config/SchedulingConfig.java
+++ b/src/main/java/com/prography/minari/common/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.prography.minari.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/prography/minari/payment/entity/Credit.java
+++ b/src/main/java/com/prography/minari/payment/entity/Credit.java
@@ -32,4 +32,8 @@ public class Credit extends BaseTimeEntity {
     public boolean isRefund() {
         return status.equals(CreditStatus.REFUND);
     }
+
+    public void changeStatusOfExpiredCredit() {
+        this.status = CreditStatus.EXPIRED;
+    }
 }

--- a/src/main/java/com/prography/minari/payment/entity/Credit.java
+++ b/src/main/java/com/prography/minari/payment/entity/Credit.java
@@ -27,10 +27,7 @@ public class Credit extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private CreditStatus status; // 사용, 환불
 
-    public LocalDateTime getExpiredAt() {
-        final int expiredTermYears = 5;
-        return getCreatedDateTime().plusYears(expiredTermYears);
-    }
+    private LocalDateTime expiredDateTime;
 
     public boolean isRefund() {
         return status.equals(CreditStatus.REFUND);

--- a/src/main/java/com/prography/minari/payment/entity/Credit.java
+++ b/src/main/java/com/prography/minari/payment/entity/Credit.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "CREDIT")
 @Getter
@@ -25,7 +27,12 @@ public class Credit extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private CreditStatus status; // 사용, 환불
 
-    public boolean isRefund(){
+    public LocalDateTime getExpiredAt() {
+        final int expiredTermYears = 5;
+        return getCreatedDateTime().plusYears(expiredTermYears);
+    }
+
+    public boolean isRefund() {
         return status.equals(CreditStatus.REFUND);
     }
 }

--- a/src/main/java/com/prography/minari/payment/entity/CreditStatus.java
+++ b/src/main/java/com/prography/minari/payment/entity/CreditStatus.java
@@ -1,5 +1,5 @@
 package com.prography.minari.payment.entity;
 
 public enum CreditStatus {
-    PAID,REFUND
+    PAID,REFUND,EXPIRED
 }

--- a/src/main/java/com/prography/minari/payment/entity/EventMeta.java
+++ b/src/main/java/com/prography/minari/payment/entity/EventMeta.java
@@ -1,0 +1,43 @@
+package com.prography.minari.payment.entity;
+
+import com.prography.minari.common.entity.BaseTimeEntity;
+import com.prography.minari.payment.service.impl.EventTrigger;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "EVENT_META")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EventMeta extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_name", nullable = false)
+    private String eventName;
+
+    @Enumerated(EnumType.STRING)
+    private EventTrigger trigger;
+
+    @Column(name = "active", nullable = false)
+    private boolean active;
+
+    @Column(name = "start_date_time", nullable = false)
+    private LocalDateTime startDateTime;
+
+    @Column(name = "end_date_time", nullable = false)
+    private LocalDateTime endDateTime;
+
+    // 이벤트 설정값 (전략별로 해석) - JSON 형태 권장
+    @Column(name = "metadata")
+    private String metadata;
+
+}

--- a/src/main/java/com/prography/minari/payment/entity/ExpirationType.java
+++ b/src/main/java/com/prography/minari/payment/entity/ExpirationType.java
@@ -1,0 +1,7 @@
+package com.prography.minari.payment.entity;
+
+public enum ExpirationType {
+    FIXED_DATETIME,
+    DURATION_DAYS,
+    DURATION_YEARS
+}

--- a/src/main/java/com/prography/minari/payment/entity/Product.java
+++ b/src/main/java/com/prography/minari/payment/entity/Product.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "PRODUCTS")
@@ -15,21 +16,41 @@ public class Product {
 
     @Column(name = "quantity")
     private Integer quantity;
+
     @Column(name = "real_price")
     private Long realPrice;
+
     @Column(name = "fake_price")
     private Long fakePrice;
+
     @Column(name = "message")
     private String message;
+
     @Column(name = "discount_rate")
     private int discountRate;
+
+    // 상품 할인 종료, 또는 이벤트 종료 시각
     @Column(name = "discount_end_date")
     private LocalDate discountEndDate;
+
+    // 상품 할인 시작, 또는 이벤트 시작 시각
     @Column(name = "discount_start_date")
     private LocalDate discountStartDate;
+
     @Column(name = "active")
     private boolean active;
+
     @Column(name = "pay_category")
     @Enumerated(EnumType.STRING)
     private PayCategory payCategory;
+
+    @Column(name = "expiration_type")
+    @Enumerated(EnumType.STRING)
+    private ExpirationType expirationType;
+
+    @Column(name = "expiration_datetime")
+    private LocalDateTime expirationDateTime;
+
+    @Column(name = "expiration_period_value")
+    private Integer expirationPeriodValue;
 }

--- a/src/main/java/com/prography/minari/payment/repository/EventMetaRepository.java
+++ b/src/main/java/com/prography/minari/payment/repository/EventMetaRepository.java
@@ -1,0 +1,23 @@
+package com.prography.minari.payment.repository;
+
+import com.prography.minari.payment.entity.EventMeta;
+import com.prography.minari.payment.service.impl.EventTrigger;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface EventMetaRepository extends JpaRepository<EventMeta,Long> {
+
+    @Query(value = "SELECT m FROM EventMeta m " +
+            "WHERE m.trigger = :trigger " +
+            "AND m.startDateTime <= :now " +
+            "AND m.endDateTime >= :now")
+    List<EventMeta> findAllByTriggerAndNowBetweenStartDateTimeAndEndDateTime(
+            @Param("trigger") EventTrigger trigger,
+            @Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/prography/minari/payment/service/impl/CreditCounter.java
+++ b/src/main/java/com/prography/minari/payment/service/impl/CreditCounter.java
@@ -2,6 +2,7 @@ package com.prography.minari.payment.service.impl;
 
 import com.prography.minari.common.aop.ImplService;
 import com.prography.minari.payment.entity.Credit;
+import com.prography.minari.payment.entity.CreditStatus;
 import com.prography.minari.payment.entity.CreditUsage;
 import com.prography.minari.payment.repository.CreditJpaRepository;
 import com.prography.minari.payment.repository.CreditUsageJpaRepository;
@@ -15,7 +16,7 @@ public class CreditCounter {
     private final CreditJpaRepository creditJpaRepository;
     private final CreditUsageJpaRepository creditUsageJpaRepository;
 
-    public Long countNotUsedCredit(Long userId){
+    public Long countNotUsedCredit(Long userId) {
         // 환불도 고려해야함.
         // 현재 씨앗의 수 = 전체 결제된 씨앗의 수 - 환불된 씨앗 - (환불안된 credit - 사용한 씨앗의 수)
         List<Credit> creditsOfUser = creditJpaRepository.findAllByUserId(userId);
@@ -29,8 +30,14 @@ public class CreditCounter {
                 .mapToLong(Credit::getAmount)
                 .sum();
 
+        long expiredCreditAmount = creditsOfUser.stream()
+                .filter(c -> CreditStatus.EXPIRED.equals(c.getStatus()))
+                .mapToLong(Credit::getAmount)
+                .sum();
+
         List<Long> usingCreditIds = creditsOfUser.stream()
                 .filter(credit -> !credit.isRefund())
+                .filter(credit -> !CreditStatus.EXPIRED.equals(credit.getStatus()))
                 .map(Credit::getId)
                 .toList();
 
@@ -39,6 +46,6 @@ public class CreditCounter {
                 .mapToLong(CreditUsage::getUsedAmount)
                 .sum();
 
-        return totalCreditAmount - refundedCreditAmount -  totalAmountOfUserUsage;
+        return totalCreditAmount - expiredCreditAmount - refundedCreditAmount - totalAmountOfUserUsage;
     }
 }

--- a/src/main/java/com/prography/minari/payment/service/impl/DailyInterviewEventStrategy.java
+++ b/src/main/java/com/prography/minari/payment/service/impl/DailyInterviewEventStrategy.java
@@ -1,0 +1,56 @@
+package com.prography.minari.payment.service.impl;
+
+import com.prography.minari.payment.entity.AccountPayment;
+import com.prography.minari.payment.entity.Credit;
+import com.prography.minari.payment.entity.CreditStatus;
+import com.prography.minari.payment.entity.Product;
+import com.prography.minari.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DailyInterviewEventStrategy implements EventStrategy {
+    private final CreditWriter creditWriter;
+    private final PaymentWriter paymentWriter;
+    private final ProductReader productReader;
+
+    @Override
+    public EventTrigger getSupportedTrigger() {
+        return EventTrigger.DAILY_INTERVIEW_EVENT;
+    }
+
+    @Override
+    public String getEventName() {
+        return "NEW_USER_GIFT";
+    }
+
+    @Override
+    public void execute(EventContext context) {
+        Long productId = Long.valueOf(context.getMetadata().get("productId").toString());
+        User user = context.getUser();
+        Optional<Product> productOpt = productReader.read(productId);
+        productOpt.ifPresentOrElse(product -> {
+            AccountPayment accountPayment = AccountPayment.create(user.getId(),
+                    productId,
+                    (long) product.getQuantity(),
+                    null,
+                    "사용자 데일리 면접진행 이벤트",
+                    null);
+            paymentWriter.write(accountPayment);
+            creditWriter.write(Credit.builder()
+                    .paymentId(accountPayment.getId())
+                    .userId(user.getId())
+                    .amount((long) product.getQuantity())
+                    .productId(productId)
+                    .status(CreditStatus.PAID)
+                    .expiredDateTime(LocalDateTime.now().toLocalDate().plusDays(1L).atStartOfDay())
+                    .build());
+        }, () -> log.info("product not found: {}", productId));
+    }
+}

--- a/src/main/java/com/prography/minari/payment/service/impl/EventContext.java
+++ b/src/main/java/com/prography/minari/payment/service/impl/EventContext.java
@@ -1,0 +1,31 @@
+package com.prography.minari.payment.service.impl;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prography.minari.payment.entity.EventMeta;
+import com.prography.minari.user.entity.User;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class EventContext {
+    private final User user;
+    private final Map<String, Object> metadata;
+    private final EventMeta event;
+
+    public EventContext(User user, EventMeta event) {
+        this.user = user;
+        this.event = event;
+        this.metadata = parseMetadata(event.getMetadata());
+    }
+
+    private Map<String, Object> parseMetadata(String json) {
+        try {
+            return new ObjectMapper().readValue(json, new TypeReference<>() {});
+        } catch (Exception e) {
+            throw new IllegalArgumentException("메타데이터 파싱 실패", e);
+        }
+    }
+
+}

--- a/src/main/java/com/prography/minari/payment/service/impl/EventExecutor.java
+++ b/src/main/java/com/prography/minari/payment/service/impl/EventExecutor.java
@@ -1,0 +1,38 @@
+package com.prography.minari.payment.service.impl;
+
+import com.prography.minari.common.aop.ImplService;
+import com.prography.minari.payment.entity.EventMeta;
+import com.prography.minari.payment.repository.EventMetaRepository;
+import com.prography.minari.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@ImplService
+@RequiredArgsConstructor
+@Slf4j
+public class EventExecutor {
+    private final List<EventStrategy> strategies;
+    private final EventMetaRepository eventMetaRepository;
+
+    public void trigger(EventTrigger triggerType, User user) {
+        LocalDateTime now = LocalDateTime.now();
+        List<EventMeta> events = eventMetaRepository.findAllByTriggerAndNowBetweenStartDateTimeAndEndDateTime(triggerType, now);
+
+        for (EventMeta event : events) {
+            if(!event.isActive()){
+                continue;
+            }
+            strategies.stream()
+                    .filter(strategy -> strategy.getSupportedTrigger().equals(triggerType))
+                    .filter(strategy -> strategy.getEventName().equals(event.getEventName()))
+                    .findFirst()
+                    .ifPresentOrElse(
+                            strategy -> strategy.execute(new EventContext(user, event)),
+                            () -> log.warn("전략 없음: {}({})", triggerType, event.getEventName())
+                    );
+        }
+    }
+}

--- a/src/main/java/com/prography/minari/payment/service/impl/EventStrategy.java
+++ b/src/main/java/com/prography/minari/payment/service/impl/EventStrategy.java
@@ -1,0 +1,7 @@
+package com.prography.minari.payment.service.impl;
+
+public interface EventStrategy {
+    EventTrigger getSupportedTrigger();
+    String getEventName();
+    void execute(EventContext context);
+}

--- a/src/main/java/com/prography/minari/payment/service/impl/EventTrigger.java
+++ b/src/main/java/com/prography/minari/payment/service/impl/EventTrigger.java
@@ -1,0 +1,10 @@
+package com.prography.minari.payment.service.impl;
+
+public enum EventTrigger {
+    USER_JOINED,
+    USER_LOGGED_IN,
+    PRODUCT_PURCHASED,
+    DAILY_SCHEDULED,
+    MANUAL_ADMIN_TRIGGERED,
+    DAILY_INTERVIEW_EVENT
+}

--- a/src/main/resources/templates/today-minari.html
+++ b/src/main/resources/templates/today-minari.html
@@ -59,15 +59,15 @@
                 <!-- 하단 아이콘들 -->
                 <tr>
                     <td align="center" style="padding-top: 20px;">
-                        <a href="https://github.com/minari-official" target="_blank" style="text-decoration: none;">
+                        <a href="https://github.com/prography/10th-3team-minari-BE" target="_blank" style="text-decoration: none;">
                             <img src="https://cdn-icons-png.flaticon.com/512/2111/2111432.png" alt="GitHub" width="24"
                                  style="margin: 0 8px; border: none;">
                         </a>
-                        <a href="https://instagram.com/minari.official" target="_blank" style="text-decoration: none;">
+                        <a href="https://www.instagram.com/official__minari" target="_blank" style="text-decoration: none;">
                             <img src="https://cdn-icons-png.flaticon.com/512/2111/2111463.png" alt="Instagram" width="24"
                                  style="margin: 0 8px; border: none;">
                         </a>
-                        <a href="https://minari-official.com/profile" target="_blank" style="text-decoration: none;">
+                        <a href="https://minari-official.com/users/my" target="_blank" style="text-decoration: none;">
                             <img src="https://cdn-icons-png.flaticon.com/512/847/847969.png" alt="Profile" width="24"
                                  style="margin: 0 8px; border: none;">
                         </a>

--- a/src/test/java/com/prography/minari/payment/repository/EventMetaRepositoryTest.java
+++ b/src/test/java/com/prography/minari/payment/repository/EventMetaRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.prography.minari.payment.repository;
+
+import com.prography.minari.payment.entity.EventMeta;
+import com.prography.minari.payment.service.impl.EventTrigger;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class EventMetaRepositoryTest {
+    @Autowired
+    private EventMetaRepository eventMetaRepository;
+
+    @Test
+    void 이벤트_조회_테스트() {
+// given
+        LocalDateTime now = LocalDateTime.of(2025, 7, 16, 12, 0);
+        EventMeta validEvent = EventMeta.builder()
+                .eventName("이벤트A")
+                .trigger(EventTrigger.DAILY_INTERVIEW_EVENT)
+                .active(true)
+                .startDateTime(now.minusDays(1))
+                .endDateTime(now.plusDays(1))
+                .metadata("{\"productId\": 10}")
+                .build();
+
+        EventMeta expiredEvent = EventMeta.builder()
+                .eventName("이벤트B")
+                .trigger(EventTrigger.DAILY_INTERVIEW_EVENT)
+                .active(true)
+                .startDateTime(now.minusDays(5))
+                .endDateTime(now.minusDays(1))
+                .metadata("{\"productId\": 11}")
+                .build();
+
+        EventMeta otherTriggerEvent = EventMeta.builder()
+                .eventName("이벤트C")
+                .trigger(EventTrigger.USER_JOINED)
+                .active(true)
+                .startDateTime(now.minusDays(1))
+                .endDateTime(now.plusDays(1))
+                .metadata("{\"productId\": 12}")
+                .build();
+
+        eventMetaRepository.saveAll(List.of(validEvent, expiredEvent, otherTriggerEvent));
+
+        // when
+        List<EventMeta> result = eventMetaRepository.findAllByTriggerAndNowBetweenStartDateTimeAndEndDateTime(
+                EventTrigger.DAILY_INTERVIEW_EVENT, now);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getEventName()).isEqualTo("이벤트A");
+    }
+}

--- a/src/test/java/com/prography/minari/payment/service/impl/CreditCounterTest.java
+++ b/src/test/java/com/prography/minari/payment/service/impl/CreditCounterTest.java
@@ -1,6 +1,7 @@
 package com.prography.minari.payment.service.impl;
 
 import com.prography.minari.payment.entity.Credit;
+import com.prography.minari.payment.entity.CreditStatus;
 import com.prography.minari.payment.entity.CreditUsage;
 import com.prography.minari.payment.repository.CreditJpaRepository;
 import com.prography.minari.payment.repository.CreditUsageJpaRepository;
@@ -35,15 +36,18 @@ class CreditCounterTest {
         when(credit1.getId()).thenReturn(1L);
         when(credit1.getAmount()).thenReturn(100L);
         when(credit1.isRefund()).thenReturn(false);
+        when(credit1.getStatus()).thenReturn(CreditStatus.PAID);
 
         Credit credit2 = mock(Credit.class);
         when(credit2.getAmount()).thenReturn(50L);
         when(credit2.isRefund()).thenReturn(true); // 환불됨
+        when(credit2.getStatus()).thenReturn(CreditStatus.REFUND);
 
         Credit credit3 = mock(Credit.class);
-        when(credit3.getId()).thenReturn(3L);
         when(credit3.getAmount()).thenReturn(200L);
         when(credit3.isRefund()).thenReturn(false);
+        when(credit3.getStatus()).thenReturn(CreditStatus.EXPIRED);
+
 
         List<Credit> creditsOfUser = List.of(credit1, credit2, credit3);
         when(creditJpaRepository.findAllByUserId(userId)).thenReturn(creditsOfUser);
@@ -55,7 +59,7 @@ class CreditCounterTest {
         when(usage2.getUsedAmount()).thenReturn(50L);
 
         List<CreditUsage> usages = List.of(usage1, usage2);
-        when(creditUsageJpaRepository.findAllByCreditIdIn(List.of(1L, 3L))).thenReturn(usages);
+        when(creditUsageJpaRepository.findAllByCreditIdIn(List.of(1L))).thenReturn(usages);
 
         // 실행
         Long result = creditService.countNotUsedCredit(userId);
@@ -68,7 +72,7 @@ class CreditCounterTest {
 
          return = 350 - 50  - 80 = 80
          */
-        assertThat(220L).isEqualTo(result);
+        assertThat(20L).isEqualTo(result);
     }
 
 }

--- a/src/test/java/com/prography/minari/payment/service/impl/DailyInterviewEventStrategyTest.java
+++ b/src/test/java/com/prography/minari/payment/service/impl/DailyInterviewEventStrategyTest.java
@@ -1,0 +1,90 @@
+package com.prography.minari.payment.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.prography.minari.payment.entity.*;
+import com.prography.minari.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DailyInterviewEventStrategyTest {
+
+    @Mock
+    private ProductReader productReader;
+
+    @Mock
+    private PaymentWriter paymentWriter;
+
+    @Mock
+    private CreditWriter creditWriter;
+
+    @InjectMocks
+    private DailyInterviewEventStrategy strategy;
+    private FixtureMonkey fixtureMonkey;
+    private ObjectMapper objectMapper = new ObjectMapper();
+    @BeforeEach
+    void setUp() {
+        fixtureMonkey = FixtureMonkey.builder()
+                .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+                .build();
+    }
+
+    @Test
+    void 사용자_데일리_최초면접진행_이벤트_크레딧발급테스트() throws Exception {
+        // given
+        User user = fixtureMonkey.giveMeBuilder(User.class)
+                .set("id", 1L)
+                .sample();
+
+        Product product = fixtureMonkey.giveMeBuilder(Product.class)
+                .set("id", 100L)
+                .set("quantity", 5)
+                .sample();
+
+        Long productId = product.getId();
+        String metadataJson = objectMapper.writeValueAsString(Map.of("productId", productId));
+        EventMeta eventMeta = fixtureMonkey.giveMeBuilder(EventMeta.class)
+                .set("metadata", metadataJson)
+                .sample();
+
+        EventContext context = new EventContext(user, eventMeta);
+
+        when(productReader.read(productId)).thenReturn(Optional.of(product));
+
+        ArgumentCaptor<AccountPayment> paymentCaptor = ArgumentCaptor.forClass(AccountPayment.class);
+        ArgumentCaptor<Credit> creditCaptor = ArgumentCaptor.forClass(Credit.class);
+
+        // when
+        strategy.execute(context);
+
+        // then
+        verify(productReader).read(productId);
+        verify(paymentWriter).write(paymentCaptor.capture());
+        verify(creditWriter).write(creditCaptor.capture());
+
+        AccountPayment writtenPayment = paymentCaptor.getValue();
+        assertEquals(user.getId(), writtenPayment.getUserId());
+        assertEquals(productId, writtenPayment.getProductId());
+        assertEquals(Long.valueOf(product.getQuantity()), writtenPayment.getAmount());
+
+        Credit writtenCredit = creditCaptor.getValue();
+        assertEquals(user.getId(), writtenCredit.getUserId());
+        assertEquals(productId, writtenCredit.getProductId());
+        assertEquals(Long.valueOf(product.getQuantity()), writtenCredit.getAmount());
+        assertEquals(CreditStatus.PAID, writtenCredit.getStatus());
+    }
+}

--- a/src/test/java/com/prography/minari/payment/service/impl/EventExecutorTest.java
+++ b/src/test/java/com/prography/minari/payment/service/impl/EventExecutorTest.java
@@ -1,0 +1,102 @@
+package com.prography.minari.payment.service.impl;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.prography.minari.payment.entity.EventMeta;
+import com.prography.minari.payment.repository.EventMetaRepository;
+import com.prography.minari.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class EventExecutorTest {
+    @Mock
+    private EventMetaRepository eventMetaRepository;
+
+    @Mock
+    private EventStrategy sampleStrategy;
+
+    @InjectMocks
+    private EventExecutor eventService; // trigger 메서드가 포함된 클래스
+
+    private FixtureMonkey fixtureMonkey;
+
+    @BeforeEach
+    void setUp() {
+        fixtureMonkey = FixtureMonkey.builder()
+                .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+                .build();
+    }
+
+    @Test
+    void 전략이_존재하면_실행된다() {
+        // given
+        EventTrigger triggerType = EventTrigger.USER_JOINED;
+        User user = fixtureMonkey.giveMeOne(User.class);
+
+        EventMeta eventMeta = EventMeta.builder()
+                .trigger(triggerType)
+                .metadata("{\n" +
+                        "  \"rewardType\": \"CREDIT\",\n" +
+                        "  \"amount\": 1000,\n" +
+                        "  \"message\": \"신규 가입을 축하합니다! 1,000 크레딧 지급\"\n" +
+                        "}")
+                .eventName("WELCOME_EVENT")
+                .build();
+
+        // 전략은 trigger와 이름이 모두 일치해야 함
+        given(eventMetaRepository.findAllByTriggerAndNowBetweenStartDateTimeAndEndDateTime(eq(triggerType), any()))
+                .willReturn(List.of(eventMeta));
+
+        given(sampleStrategy.getSupportedTrigger()).willReturn(EventTrigger.USER_JOINED);
+        given(sampleStrategy.getEventName()).willReturn("WELCOME_EVENT");
+
+        // 전략 리스트 주입
+        eventService = new EventExecutor(List.of(sampleStrategy),eventMetaRepository);
+
+        // when
+        eventService.trigger(triggerType, user);
+
+        // then
+        verify(sampleStrategy).execute(any(EventContext.class));
+    }
+
+    @Test
+    void 전략이_존재하지_않으면_실행되지_않는다() {
+        // given
+        EventTrigger triggerType = EventTrigger.USER_JOINED;
+        User user = fixtureMonkey.giveMeOne(User.class);
+
+        EventMeta eventMeta = EventMeta.builder()
+                .trigger(triggerType)
+                .eventName("WELCOME_EVENT")
+                .build();
+
+        given(eventMetaRepository.findAllByTriggerAndNowBetweenStartDateTimeAndEndDateTime(eq(triggerType), any()))
+                .willReturn(List.of(eventMeta));
+
+        // 전략은 존재하되 이름이 다름
+        given(sampleStrategy.getSupportedTrigger()).willReturn(EventTrigger.USER_JOINED);
+        given(sampleStrategy.getEventName()).willReturn("OTHER_EVENT");
+
+        eventService = new EventExecutor(List.of(sampleStrategy),eventMetaRepository);
+
+        // when
+        eventService.trigger(triggerType, user);
+
+        // then
+        verify(sampleStrategy, never()).execute(any());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#131 

## 📝작업 내용
이벤트 실행 로직을 추가했습니다.
EventExecutor: 이벤트 실행로직 탐색 구현체
EventStrategy: 이벤트 실행 구현체

1. EventExecutor를 통해 실행할수 있는 EventStrategy를 탐색
2. EventStrategy가 EventMeta를 조회하여 로직 실행

이후 이벤트가 추가적으로 진행될때 EventExecutor와 EventStrategy만 구현하면 이벤트 구현이 가능합니다!


## 💬리뷰 요구사항(선택)
### 깃이 꼬일거 같아서,  #134 이것 먼저 머지 부탁드려요!!!
- 아직 만료된 Credit 처리하는 스케줄러 로직은 추가되지 않았습니다!
- 코드가 조금 더러워지고 있는것 같아요... 구현체로 한다는것이 오히려 Service에 의존을 높이고 있는것은 아닐지 갑자기 고민이네요..! 좋은 방법있으신가요? 뭔가 Reader와 Writer가 너무 많아 그런거같다는 생각이 들어요..!
- 엔티티도 복잡해지고 있어서, 혹시 어떻게 사용되고 있는지 모르겠는것은 언제든 물어봐주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an event-driven system for handling user actions and rewards, including support for daily interview events and event metadata management.
  * Added support for managing product and credit expiration, including new expiration types and status tracking.
  * Implemented scheduled batch jobs to automatically update the status of expired credits.

* **Improvements**
  * Enhanced email notifications with dynamic subject lines reflecting the current date.
  * Updated social and profile links in the "오늘의 미나리" page footer.

* **Bug Fixes**
  * Improved credit calculation logic to properly account for expired credits.

* **Tests**
  * Added comprehensive tests for event strategies, event execution, credit expiration, and repository queries to ensure reliability of new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->