### PR TITLE
[Fix(#144)] left join으로 인해 answer의 개수만큼 로우가 생겨서 중복 질문 조회 오류 수정

### DIFF
--- a/src/main/java/com/prography/minari/question/repository/QuestionRepository.java
+++ b/src/main/java/com/prography/minari/question/repository/QuestionRepository.java
@@ -18,12 +18,10 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     @Query("""
     SELECT q
     FROM Question q
-    LEFT JOIN Answer a ON a.question = q AND a.user.id = :userId
-    WHERE (:domains IS NULL OR q.domain IN :domains)
+    WHERE q.domain IN :domains
     ORDER BY q.orderNum ASC
     """)
     Page<Question> findDailyUnsolvedQuestionByDomains(
-            @Param("userId") Long userId,
             @Param("domains") List<Domain> domains,
             Pageable pageable
     );

--- a/src/main/java/com/prography/minari/question/service/impl/QuestionReader.java
+++ b/src/main/java/com/prography/minari/question/service/impl/QuestionReader.java
@@ -27,7 +27,7 @@ public class QuestionReader {
 
     public Optional<Question> readDaily(User user, List<Domain> domains, long day) {
         return questionRepository
-                .findDailyUnsolvedQuestionByDomains(user.getId(), domains, PageRequest.of((int) day, 1))
+                .findDailyUnsolvedQuestionByDomains(domains, PageRequest.of((int) day, 1))
                 .getContent().stream().findFirst();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#144 

## 📝작업 내용
- left join으로 인해 answer의 개수만큼 로우가 생겨서 중복 질문 조회 오류 수정
- left join 삭제

## 💬리뷰 요구사항(선택)
hot fix여서 셀프머지 하였습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the logic for retrieving daily unsolved questions by simplifying the filtering process. The selection now focuses solely on the specified domains and sorts questions by order, potentially enhancing performance and reliability. No changes to user-facing features or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->