### PR TITLE
[FEAT(#146)] 이메일 인증 요청 시, 이미 등록된 이메일인 경우 예외 처리

### DIFF
--- a/src/main/java/com/prography/minari/common/execption/ErrorCode.java
+++ b/src/main/java/com/prography/minari/common/execption/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     EMAIL_INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "잘못된 이메일 주소입니다.", "MAIL001"),
     EMAIL_MESSAGE_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 메시지 생성 중 오류가 발생했습니다.", "MAIL002"),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다.", "MAIL003"),
+    EXISTS_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이미 존재하는 이메일입니다.", "MAIL004"),
     METHOD_ARGUMENT_NOT_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "", "VALIDATION"),
     AUDIO_UNSUPPORT_FORMAT_EXCEPTION(HttpStatus.NOT_FOUND, "지원하지 않는 오디오 포맷입니다.","AU003"),
     REQUEST_BODY_IS_MISSING(HttpStatus.NOT_FOUND, "Request Body가 존재하지 않습니다.", "VALIDATION"),

--- a/src/main/java/com/prography/minari/mail/service/MailService.java
+++ b/src/main/java/com/prography/minari/mail/service/MailService.java
@@ -10,6 +10,7 @@ import com.prography.minari.mail.repository.MailAuthLogRepository;
 import com.prography.minari.mail.service.impl.MailTemplateCreater;
 import com.prography.minari.user.dto.MailVerificationCheckReqDto;
 import com.prography.minari.user.entity.User;
+import com.prography.minari.user.service.impl.UserReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.Map;
 
+import static com.prography.minari.common.execption.ErrorCode.EXISTS_EMAIL;
 import static com.prography.minari.mail.dto.MailSubject.AUTH_SUBJECT;
 
 @Service
@@ -27,8 +29,18 @@ public class MailService {
     private final MailTemplateCreater mailTemplateCreater;
     private final MailClient mailClient;
     private final MailAuthLogRepository mailAuthLogRepository;
+    private final UserReader userReader;
 
     public void sendAuthMail(MailVerificationReqDto mailVerificationReqDto, User user) {
+
+        String email       = mailVerificationReqDto.to();
+        String redirectUri = mailVerificationReqDto.redirectUri();
+
+        // 이미 등록된 이메일인 경우, [MAIL004] 이미 존재하는 이메일입니다.
+        if(userReader.existsByEmail(email)) {
+            log.info("[{}] : {}", EXISTS_EMAIL.getCode(), EXISTS_EMAIL.getMessage());
+            throw new ApiException(EXISTS_EMAIL);
+        }
 
         // 숫자로 구성된 6자리인증 코드 생성
         String authCode = AuthCodeUtil.generate6DigitCode();
@@ -41,8 +53,8 @@ public class MailService {
 
         // 인증 메일 양식 만들기
         MailRequest authMailRequest = mailTemplateCreater.create(AUTH_SUBJECT.getName(),
-                mailVerificationReqDto.to(),
-                Map.of("verificationLink", mailVerificationReqDto.redirectUri(),"authCode",authCode),
+                email,
+                Map.of("verificationLink", redirectUri,"authCode",authCode),
                 "auth-mail");
         // 인증 메일 전송
         mailClient.sendMail(authMailRequest);

--- a/src/main/java/com/prography/minari/user/repository/UserRepository.java
+++ b/src/main/java/com/prography/minari/user/repository/UserRepository.java
@@ -15,4 +15,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByUuid(String uuid);
 
+    boolean existsByEmail(String email);
+
 }

--- a/src/main/java/com/prography/minari/user/service/impl/UserReader.java
+++ b/src/main/java/com/prography/minari/user/service/impl/UserReader.java
@@ -40,4 +40,8 @@ public class UserReader {
     public User readByUUID(String uuid) {
         return userRepository.findByUuid(uuid).orElseThrow(() -> new RuntimeException("User not found"));
     }
+
+    public boolean existsByEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#146 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 💬리뷰 요구사항(선택)

> 간단한 로직 수정입니다~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a check to prevent sending authentication emails to addresses that are already registered. Users will now receive an error message if they attempt to verify an email that already exists in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->