### PR TITLE
[Fix(#155)] 프로모션 중복참여 방어로직 추가

### DIFF
--- a/src/main/java/com/prography/minari/payment/repository/CreditJpaRepository.java
+++ b/src/main/java/com/prography/minari/payment/repository/CreditJpaRepository.java
@@ -2,11 +2,20 @@ package com.prography.minari.payment.repository;
 
 import com.prography.minari.payment.entity.Credit;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CreditJpaRepository extends JpaRepository<Credit, Long> {
     List<Credit> findAllByUserId(Long userId);
+
+    @Query("SELECT c FROM Credit c WHERE c.productId = :productId AND c.createdDateTime BETWEEN :start AND :end")
+    Optional<Credit> findByProductIdAndCreatedAtToday(@Param("productId") Long productId,
+                                                      @Param("start") LocalDateTime start,
+                                                      @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/prography/minari/payment/service/impl/CreditReader.java
+++ b/src/main/java/com/prography/minari/payment/service/impl/CreditReader.java
@@ -1,0 +1,22 @@
+package com.prography.minari.payment.service.impl;
+
+import com.prography.minari.common.aop.ImplService;
+import com.prography.minari.payment.entity.Credit;
+import com.prography.minari.payment.repository.CreditJpaRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@ImplService
+@RequiredArgsConstructor
+public class CreditReader {
+    private final CreditJpaRepository creditJpaRepository;
+
+    public Optional<Credit> readGetTodayByProductId(Long productId) {
+        return creditJpaRepository.findByProductIdAndCreatedAtToday(
+                productId,
+                LocalDateTime.now().toLocalDate().atStartOfDay(),
+                LocalDateTime.now().plusDays(1L).toLocalDate().atStartOfDay());
+    }
+}

--- a/src/main/java/com/prography/minari/payment/service/impl/DailyInterviewEventStrategy.java
+++ b/src/main/java/com/prography/minari/payment/service/impl/DailyInterviewEventStrategy.java
@@ -19,6 +19,7 @@ public class DailyInterviewEventStrategy implements EventStrategy {
     private final CreditWriter creditWriter;
     private final PaymentWriter paymentWriter;
     private final ProductReader productReader;
+    private final CreditReader creditReader;
 
     @Override
     public EventTrigger getSupportedTrigger() {
@@ -34,6 +35,10 @@ public class DailyInterviewEventStrategy implements EventStrategy {
     public void execute(EventContext context) {
         Long productId = Long.valueOf(context.getMetadata().get("productId").toString());
         User user = context.getUser();
+        Optional<Credit> todayGetPromotionCredit = creditReader.readGetTodayByProductId(productId);
+        if(todayGetPromotionCredit.isPresent()){
+            return;
+        }
         Optional<Product> productOpt = productReader.read(productId);
         productOpt.ifPresentOrElse(product -> {
             AccountPayment accountPayment = AccountPayment.create(user.getId(),


### PR DESCRIPTION
## #️⃣연관된 이슈
#155 


## 📝작업 내용
- 동일한 product의 개수를 통해 프로모션 중복참여 방어로직 추가

## 💬리뷰 요구사항(선택)
없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The system now checks if a promotion credit has already been issued for a product on the current day, preventing duplicate credits for the same product within a day.

* **Bug Fixes**
  * Improved handling to ensure users do not receive multiple promotion credits for the same product on the same day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->