### PR TITLE
[REFACTOR(#148)] 이메일 인증 코드 저장소를 PostgreSQL → Redis로 변경

### DIFF
--- a/src/main/java/com/prography/minari/common/service/impl/RedisProcessor.java
+++ b/src/main/java/com/prography/minari/common/service/impl/RedisProcessor.java
@@ -20,18 +20,18 @@ import static com.prography.minari.common.execption.ErrorCode.JWT_NOT_MATCHED;
 @RequiredArgsConstructor
 public class RedisProcessor {
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, String> redisTemplate;
     private final JwtUtil jwtUtil;
 
     /**
      * Redis에 데이터 저장 (만료시간 설정)
      */
-    public void setValue(String key, Object value) {
-        redisTemplate.opsForValue().set(key, value, jwtUtil.getDuration(value.toString()));
+    public void setValue(String key, String value) {
+        redisTemplate.opsForValue().set(key, value, jwtUtil.getDuration(value));
         log.info("refresh token 저장 : {}", value);
     }
 
-    public void setValue(String key, Object value, Duration duration) {
+    public void setValue(String key, String value, Duration duration) {
         redisTemplate.opsForValue().set(key, value, duration);
         log.info("[REDIS] {} : {}", key, value);
     }

--- a/src/main/java/com/prography/minari/common/service/impl/RedisProcessor.java
+++ b/src/main/java/com/prography/minari/common/service/impl/RedisProcessor.java
@@ -9,8 +9,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import static com.prography.minari.common.execption.ErrorCode.ENTITY_NOT_FOUND;
 import static com.prography.minari.common.execption.ErrorCode.JWT_NOT_MATCHED;
 
 @Slf4j
@@ -29,18 +31,26 @@ public class RedisProcessor {
         log.info("refresh token 저장 : {}", value);
     }
 
+    public void setValue(String key, Object value, Duration duration) {
+        redisTemplate.opsForValue().set(key, value, duration);
+        log.info("[REDIS] {} : {}", key, value);
+    }
+
     /**
      * Redis에서 데이터 조회
      */
-    public Object getValue(String key) {
-        return redisTemplate.opsForValue().get(key);
+    public Optional<Object> getValue(String key) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(key));
     }
 
     /**
      * Redis에서 데이터 삭제
      */
     public Boolean deleteValue(String key) {
-        log.info("refresh token 삭제 : {}", getValue(key));
+        // Redis에 key 값과 매칭되는 객체가 존재하지 않으면, 예외처리
+        Object value = getValue(key).orElseThrow(() -> new ApiException(ENTITY_NOT_FOUND));
+
+        log.info("refresh token 삭제 : {}", value);
         return redisTemplate.delete(key);
     }
 
@@ -63,18 +73,6 @@ public class RedisProcessor {
      */
     public Long getExpire(String key) {
         return redisTemplate.getExpire(key);
-    }
-
-    /**
-     * 토큰 일치 검증 메소드
-     */
-    public void validateRefreshToken(String key, String refreshToken) {
-        String targetRefreshToken = redisTemplate.opsForValue().get(key).toString();
-        // redis에 저장된 토큰과 사용자가 제공한 토큰일 일치하지 않을 경우, 예외처리
-        if(!targetRefreshToken.equals(refreshToken)) {
-            log.info("저장된 refreshToken : {} \n제공한 refreshToken : {}", targetRefreshToken, refreshToken);
-            throw new ApiException(JWT_NOT_MATCHED);
-        }
     }
 
 }

--- a/src/main/java/com/prography/minari/common/service/impl/RedisProcessor.java
+++ b/src/main/java/com/prography/minari/common/service/impl/RedisProcessor.java
@@ -47,10 +47,7 @@ public class RedisProcessor {
      * Redis에서 데이터 삭제
      */
     public Boolean deleteValue(String key) {
-        // Redis에 key 값과 매칭되는 객체가 존재하지 않으면, 예외처리
-        Object value = getValue(key).orElseThrow(() -> new ApiException(ENTITY_NOT_FOUND));
-
-        log.info("refresh token 삭제 : {}", value);
+        log.info("refresh token 삭제 : {}", key);
         return redisTemplate.delete(key);
     }
 

--- a/src/main/java/com/prography/minari/mail/service/MailService.java
+++ b/src/main/java/com/prography/minari/mail/service/MailService.java
@@ -2,6 +2,7 @@ package com.prography.minari.mail.service;
 
 import com.prography.minari.common.execption.ApiException;
 import com.prography.minari.common.execption.ErrorCode;
+import com.prography.minari.common.service.impl.RedisProcessor;
 import com.prography.minari.common.util.AuthCodeUtil;
 import com.prography.minari.mail.dto.MailRequest;
 import com.prography.minari.mail.dto.MailVerificationReqDto;
@@ -15,10 +16,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Map;
 
-import static com.prography.minari.common.execption.ErrorCode.EXISTS_EMAIL;
+import static com.prography.minari.common.execption.ErrorCode.*;
 import static com.prography.minari.mail.dto.MailSubject.AUTH_SUBJECT;
 
 @Service
@@ -30,6 +32,8 @@ public class MailService {
     private final MailClient mailClient;
     private final MailAuthLogRepository mailAuthLogRepository;
     private final UserReader userReader;
+    private final RedisProcessor redisProcessor;
+
 
     public void sendAuthMail(MailVerificationReqDto mailVerificationReqDto, User user) {
 
@@ -38,18 +42,16 @@ public class MailService {
 
         // 이미 등록된 이메일인 경우, [MAIL004] 이미 존재하는 이메일입니다.
         if(userReader.existsByEmail(email)) {
-            log.info("[{}] : {}", EXISTS_EMAIL.getCode(), EXISTS_EMAIL.getMessage());
+            log.info("[{}] : {}, {}", EXISTS_EMAIL.getCode(), EXISTS_EMAIL.getMessage(), email);
             throw new ApiException(EXISTS_EMAIL);
         }
 
         // 숫자로 구성된 6자리인증 코드 생성
         String authCode = AuthCodeUtil.generate6DigitCode();
-
         log.info("[메일 인증] userId: {}, 인증코드: {}", user.getId(), authCode);
 
-        // 인증번호 데이터베이스에 저장하기
-        //TODO 차후에 Redis로 변경
-        mailAuthLogRepository.save(MailAuthLog.create(user.getId(), authCode));
+        // 인증번호 레디스에 적재하기
+        redisProcessor.setValue(user.getUuid(), authCode, Duration.ofMinutes(3));
 
         // 인증 메일 양식 만들기
         MailRequest authMailRequest = mailTemplateCreater.create(AUTH_SUBJECT.getName(),
@@ -60,25 +62,18 @@ public class MailService {
         mailClient.sendMail(authMailRequest);
     }
 
-    /**
-     * Verifies the provided email authentication code for a user.
-     *
-     * Checks that the most recent authentication code for the user matches the provided code and has not expired.
-     * Throws an exception if the code is missing, invalid, or expired.
-     */
     public void verifyAuthCode(MailVerificationCheckReqDto mailVerificationCheckReqDto, User user) {
-        MailAuthLog mailAuthLog = mailAuthLogRepository.findFirstByUserIdOrderByCreatedDateTimeDesc(user.getId())
-                .orElseThrow(() -> new ApiException(ErrorCode.ENTITY_NOT_FOUND));
+
+        String authCode = redisProcessor.getValue(user.getUuid())
+                .orElseThrow(() -> new ApiException(EXPIRED_AUTH_CODE))
+                .toString();
 
         // 유효햐지 않은 인증번호입니다.
-        if (!mailAuthLog.getAuthCode().equals(mailVerificationCheckReqDto.authCode())) {
+        if (!authCode.equals(mailVerificationCheckReqDto.authCode())) {
+            log.info("저장된 auth-code : {}, 요청한 auth-code : {}", authCode, mailVerificationCheckReqDto.authCode());
             throw new ApiException(ErrorCode.INVALID_AUTH_CODE);
         }
 
-        // 인증번호가 만료되었습니다.
-        if (mailAuthLog.getExpiredAt().isBefore(LocalDateTime.now())) {
-            throw new ApiException(ErrorCode.EXPIRED_AUTH_CODE);
-        }
     }
 
 }

--- a/src/main/java/com/prography/minari/user/service/UserService.java
+++ b/src/main/java/com/prography/minari/user/service/UserService.java
@@ -19,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import static com.prography.minari.common.execption.ErrorCode.JWT_NOT_MATCHED;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -67,8 +69,14 @@ public class UserService {
         String userId = jwtUtil.getUserId(refreshToken);
         String userRole = jwtUtil.getUserRole(refreshToken);
 
+        // refresh token 조회
+        String storedRefreshToken = redisProcessor.getValue(userId)
+                .orElseThrow(() -> new ApiException(JWT_NOT_MATCHED))
+                .toString();
+
         // refresh token 검증
-        redisProcessor.validateRefreshToken(userId, refreshToken);
+        if(!storedRefreshToken.equals(refreshToken))
+            throw new ApiException(JWT_NOT_MATCHED);
 
         // JWT 발급
         String newAccessToken = jwtUtil.createAccessToken(userId, userRole);


### PR DESCRIPTION
## #️⃣연관된 이슈

#148 

## 📝작업 내용

이메일 인증 코드를 데이터베이스 적재에서, redis로 적재 변경하도록 수정하였습니다.

### 📄 RedisProcessor.java
- 만료시간까지 포함하여 Redis에 적재하는 메소드 setValue()를 생성하였습니다.
- getValue() 메소드, Null 처리를 위해 Optional 래핑 추가

```java
    public void setValue(String key, Object value, Duration duration) {
        redisTemplate.opsForValue().set(key, value, duration);
        log.info("[REDIS] {} : {}", key, value);
    }

    // ASIS
    public Object getValue(String key) {
        return redisTemplate.opsForValue().get(key);
    }
    // TOBE
    public Optional<Object> getValue(String key) {
        return Optional.ofNullable(redisTemplate.opsForValue().get(key));
    }

```

### 📄 MailService.java
- 이메일 인증코드 적재를 PostrgreSQL에서 Redis로 변경
- 이메일 인증코드 조회를 PostrgreSQL에서 Redis로 변경

```java
public void sendAuthMail(MailVerificationReqDto mailVerificationReqDto, User user) {

    // ASIS
    mailAuthLogRepository.save(MailAuthLog.create(user.getId(), authCode));    

    //TOBE
    redisProcessor.setValue(user.getUuid(), authCode, Duration.ofMinutes(3));

}

public void verifyAuthCode(MailVerificationCheckReqDto mailVerificationCheckReqDto, User user) {

    String authCode = redisProcessor.getValue(user.getUuid())
            .orElseThrow(() -> new ApiException(EXPIRED_AUTH_CODE))
            .toString();

    // 유효햐지 않은 인증번호입니다.
    if (!authCode.equals(mailVerificationCheckReqDto.authCode())) {
        log.info("저장된 auth-code : {}, 요청한 auth-code : {}", authCode, mailVerificationCheckReqDto.authCode());
        throw new ApiException(ErrorCode.INVALID_AUTH_CODE);
    }

}
```

### 📄 UserService.java
- 토큰 검증 메소드 validateRefreshToken()을 삭제하고, 로직 처리를 RedisProcessor에서 UserService로 책임을 이관
- RedisProcessor가 순수하게 Redis 데이터 처리만 할 수 있도록 로직 분리
```java
public UserRefreshTokenResDto createToken(String refreshToken) {

    // user 정보 추출
    String userId = jwtUtil.getUserId(refreshToken);
    String userRole = jwtUtil.getUserRole(refreshToken);

    // refresh token 조회
    String storedRefreshToken = redisProcessor.getValue(userId)
            .orElseThrow(() -> new ApiException(JWT_NOT_MATCHED))
            .toString();

    // refresh token 검증
    if(!storedRefreshToken.equals(refreshToken))
        throw new ApiException(JWT_NOT_MATCHED);

    // JWT 발급
    String newAccessToken = jwtUtil.createAccessToken(userId, userRole);
    String newRefreshToken = jwtUtil.createRefreshToken(userId, userRole);

    // redis에 적재
    redisProcessor.setValue(userId, newRefreshToken);

    return UserRefreshTokenResDto.from(newAccessToken, newRefreshToken);
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of temporary data and authentication codes using in-memory caching for faster and more reliable operations.

* **Bug Fixes**
  * Enhanced error handling and messaging when retrieving or deleting cached values, providing clearer feedback on missing or expired data.

* **Refactor**
  * Streamlined authentication code verification and refresh token validation processes for better security and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->