### PR TITLE
[REFACTOR(#149)] 미나리 달성률 -> 연속 N일차 달성 값으로 변경

### DIFF
--- a/src/main/java/com/prography/minari/answer/service/AnswerService.java
+++ b/src/main/java/com/prography/minari/answer/service/AnswerService.java
@@ -175,10 +175,10 @@ public class AnswerService {
                 })
                 .collect(Collectors.toList());
 
-        // 미나리 달성률
-        int achievementRate = AnalyticsUtil.calculateAchievementRate(answerResList, startDate, endDate);
+        // 미나리 N일 연속
+        int consecutiveDays = AnalyticsUtil.calculateConsecutiveDaysCount(answerResList, startDate, endDate);
 
-        return AnswerHistoryResDto.create(achievementRate, answerResList);
+        return AnswerHistoryResDto.create(consecutiveDays, answerResList);
     }
 
     public InterviewAccessStatus determineInterviewAccess(User user) {

--- a/src/main/java/com/prography/minari/answer/service/AnswerService.java
+++ b/src/main/java/com/prography/minari/answer/service/AnswerService.java
@@ -176,7 +176,7 @@ public class AnswerService {
                 .collect(Collectors.toList());
 
         // 미나리 N일 연속
-        int consecutiveDays = AnalyticsUtil.calculateConsecutiveDaysCount(answerResList, startDate, endDate);
+        int consecutiveDays = AnalyticsUtil.calculateConsecutiveDaysCount(answerMap);
 
         return AnswerHistoryResDto.create(consecutiveDays, answerResList);
     }

--- a/src/main/java/com/prography/minari/common/util/AnalyticsUtil.java
+++ b/src/main/java/com/prography/minari/common/util/AnalyticsUtil.java
@@ -4,7 +4,11 @@ import com.prography.minari.answer.dto.res.AnswerResDto;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class AnalyticsUtil {
 
@@ -22,6 +26,23 @@ public class AnalyticsUtil {
     public static int toPercentage(long numerator, long denominator) {
         if (denominator == 0) return 0;
         return Math.toIntExact(Math.round(numerator * 100.0 / denominator));
+    }
+
+    public static int calculateConsecutiveDaysCount(List<AnswerResDto> answers, LocalDate startDate, LocalDate endDate) {
+
+        LocalDate today = LocalDate.now();
+
+        return Math.toIntExact(
+                answers.stream()
+                        .filter(dto -> {
+                            LocalDate date = dto.answerDate();
+                            return !date.isBefore(startDate) && !date.isAfter(today);
+                        })
+                        .sorted(Comparator.comparing(AnswerResDto::answerDate).reversed())
+                        .map(AnswerResDto::isExisted)
+                        .takeWhile(Boolean.TRUE::equals)
+                        .count()
+        );
     }
 
 }

--- a/src/main/java/com/prography/minari/common/util/AnalyticsUtil.java
+++ b/src/main/java/com/prography/minari/common/util/AnalyticsUtil.java
@@ -32,17 +32,23 @@ public class AnalyticsUtil {
 
         LocalDate today = LocalDate.now();
 
-        return Math.toIntExact(
+        // 오늘 리허설을 진행했다면, 1 추가
+        int consecutiveDays = answers.stream()
+                .anyMatch(dto -> dto.answerDate().isEqual(today) && dto.isExisted()) ? 1 : 0;
+
+        consecutiveDays += Math.toIntExact(
                 answers.stream()
                         .filter(dto -> {
                             LocalDate date = dto.answerDate();
-                            return !date.isBefore(startDate) && !date.isAfter(today);
+                            return !date.isBefore(startDate) && !date.isAfter(today.minusDays(1));
                         })
                         .sorted(Comparator.comparing(AnswerResDto::answerDate).reversed())
                         .map(AnswerResDto::isExisted)
                         .takeWhile(Boolean.TRUE::equals)
                         .count()
         );
+
+        return consecutiveDays;
     }
 
 }

--- a/src/main/java/com/prography/minari/common/util/AnalyticsUtil.java
+++ b/src/main/java/com/prography/minari/common/util/AnalyticsUtil.java
@@ -1,6 +1,7 @@
 package com.prography.minari.common.util;
 
 import com.prography.minari.answer.dto.res.AnswerResDto;
+import com.prography.minari.answer.entity.Answer;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -28,25 +29,18 @@ public class AnalyticsUtil {
         return Math.toIntExact(Math.round(numerator * 100.0 / denominator));
     }
 
-    public static int calculateConsecutiveDaysCount(List<AnswerResDto> answers, LocalDate startDate, LocalDate endDate) {
+    public static int calculateConsecutiveDaysCount(Map<LocalDate, Answer> answers) {
 
+        // 기준값(today) 선언
         LocalDate today = LocalDate.now();
 
-        // 오늘 리허설을 진행했다면, 1 추가
-        int consecutiveDays = answers.stream()
-                .anyMatch(dto -> dto.answerDate().isEqual(today) && dto.isExisted()) ? 1 : 0;
+        // 오늘 문제를 풀었다면 1일, 풀지 않았다면 0일부터 시작!
+        int consecutiveDays = answers.containsKey(today) ? 1 : 0;
 
-        consecutiveDays += Math.toIntExact(
-                answers.stream()
-                        .filter(dto -> {
-                            LocalDate date = dto.answerDate();
-                            return !date.isBefore(startDate) && !date.isAfter(today.minusDays(1));
-                        })
-                        .sorted(Comparator.comparing(AnswerResDto::answerDate).reversed())
-                        .map(AnswerResDto::isExisted)
-                        .takeWhile(Boolean.TRUE::equals)
-                        .count()
-        );
+        // 오늘을 기준으로 1일전, 2일전, 3일전, ... 문제를 풀었다면 연속일수 값을 1 증가!
+        for(LocalDate date = today.minusDays(1); answers.containsKey(date); date = date.minusDays(1)) {
+            consecutiveDays++;
+        }
 
         return consecutiveDays;
     }

--- a/src/test/java/com/prography/minari/common/util/AnalyticsUtilTest.java
+++ b/src/test/java/com/prography/minari/common/util/AnalyticsUtilTest.java
@@ -1,62 +1,113 @@
 package com.prography.minari.common.util;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
-import com.prography.minari.answer.dto.res.AnswerResDto;
-import org.junit.jupiter.api.BeforeEach;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.prography.minari.answer.entity.Answer;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-import java.util.Random;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class AnalyticsUtilTest {
 
-    private static final Logger log = LoggerFactory.getLogger(AnalyticsUtilTest.class);
-    private Random random = new Random();
+    private static FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .build();
 
     @Test
-    void calculateConsecutiveDaysCount() {
+    void calculateConsecutiveDaysCount_0일() {
 
         // given
-        LocalDate now = LocalDate.now();
-        LocalDate startDate = now.minusDays(15);
-        LocalDate endDate = now.plusDays(15);
-
-        List<AnswerResDto> answerResDtoList = Stream
-                .iterate(startDate, date -> !date.isAfter(endDate), date -> date.plusDays(1))
-                .map(date -> new AnswerResDto(random.nextBoolean(), 0L, date, 0L))
-                .toList();
-
-        Map<LocalDate, Boolean> answerExistMap = answerResDtoList.stream()
-                .collect(Collectors.toMap(
-                        AnswerResDto::answerDate,
-                        AnswerResDto::isExisted
-                ));
-
-        int realCount = 0;
-        for(LocalDate date = now; !date.isBefore(startDate); date = date.minusDays(1)) {
-            if(!answerExistMap.get(date)) {
-                if(date.equals(now)) continue;
-                break;
-            }
-            realCount++;
-        }
+        LocalDate today = LocalDate.now();
+        Map<LocalDate, Answer> localDateAnswerMap = Map.of(
+                today.minusDays(2), fixtureMonkey.giveMeOne(Answer.class),
+                today.minusDays(3), fixtureMonkey.giveMeOne(Answer.class),
+                today.minusDays(4), fixtureMonkey.giveMeOne(Answer.class)
+        );
 
         // when
-        int calculateCount = AnalyticsUtil.calculateConsecutiveDaysCount(answerResDtoList, startDate, endDate);
+        int calculateCount = AnalyticsUtil.calculateConsecutiveDaysCount(localDateAnswerMap);
 
         // then
-        assertEquals(realCount, calculateCount);
+        assertEquals(0, calculateCount);
+
+    }
+
+    @Test
+    void calculateConsecutiveDaysCount_1일_오늘() {
+
+        // given
+        LocalDate today = LocalDate.now();
+        Map<LocalDate, Answer> localDateAnswerMap = Map.of(
+                today.minusDays(0), fixtureMonkey.giveMeOne(Answer.class),
+                today.minusDays(2), fixtureMonkey.giveMeOne(Answer.class),
+                today.minusDays(3), fixtureMonkey.giveMeOne(Answer.class)
+        );
+
+        // when
+        int calculateCount = AnalyticsUtil.calculateConsecutiveDaysCount(localDateAnswerMap);
+
+        // then
+        assertEquals(1, calculateCount);
+
+    }
+
+    @Test
+    void calculateConsecutiveDaysCount_1일_어제() {
+
+        // given
+        LocalDate today = LocalDate.now();
+        Map<LocalDate, Answer> localDateAnswerMap = Map.of(
+                today.minusDays(1), fixtureMonkey.giveMeOne(Answer.class),
+                today.minusDays(3), fixtureMonkey.giveMeOne(Answer.class),
+                today.minusDays(4), fixtureMonkey.giveMeOne(Answer.class)
+        );
+
+        // when
+        int calculateCount = AnalyticsUtil.calculateConsecutiveDaysCount(localDateAnswerMap);
+
+        // then
+        assertEquals(1, calculateCount);
+
+    }
+
+    @Test
+    void calculateConsecutiveDaysCount_2일_오늘() {
+
+        // given
+        LocalDate today = LocalDate.now();
+        Map<LocalDate, Answer> localDateAnswerMap = Map.of(
+                today.minusDays(0), fixtureMonkey.giveMeOne(Answer.class),
+                today.minusDays(1), fixtureMonkey.giveMeOne(Answer.class),
+                today.minusDays(4), fixtureMonkey.giveMeOne(Answer.class)
+        );
+
+        // when
+        int calculateCount = AnalyticsUtil.calculateConsecutiveDaysCount(localDateAnswerMap);
+
+        // then
+        assertEquals(2, calculateCount);
+
+    }
+
+    @Test
+    void calculateConsecutiveDaysCount_2일_어제() {
+
+        // given
+        LocalDate today = LocalDate.now();
+        Map<LocalDate, Answer> localDateAnswerMap = Map.of(
+                today.minusDays(1), fixtureMonkey.giveMeOne(Answer.class),
+                today.minusDays(2), fixtureMonkey.giveMeOne(Answer.class),
+                today.minusDays(4), fixtureMonkey.giveMeOne(Answer.class)
+        );
+
+        // when
+        int calculateCount = AnalyticsUtil.calculateConsecutiveDaysCount(localDateAnswerMap);
+
+        // then
+        assertEquals(2, calculateCount);
 
     }
 

--- a/src/test/java/com/prography/minari/common/util/AnalyticsUtilTest.java
+++ b/src/test/java/com/prography/minari/common/util/AnalyticsUtilTest.java
@@ -1,0 +1,63 @@
+package com.prography.minari.common.util;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.prography.minari.answer.dto.res.AnswerResDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AnalyticsUtilTest {
+
+    private static final Logger log = LoggerFactory.getLogger(AnalyticsUtilTest.class);
+    private Random random = new Random();
+
+    @Test
+    void calculateConsecutiveDaysCount() {
+
+        // given
+        LocalDate now = LocalDate.now();
+        LocalDate startDate = now.minusDays(15);
+        LocalDate endDate = now.plusDays(15);
+
+        List<AnswerResDto> answerResDtoList = Stream
+                .iterate(startDate, date -> !date.isAfter(endDate), date -> date.plusDays(1))
+                .map(date -> new AnswerResDto(random.nextBoolean(), 0L, date, 0L))
+                .toList();
+
+        Map<LocalDate, Boolean> answerExistMap = answerResDtoList.stream()
+                .collect(Collectors.toMap(
+                        AnswerResDto::answerDate,
+                        AnswerResDto::isExisted
+                ));
+
+        int realCount = 0;
+        for(LocalDate date = now; !date.isBefore(startDate); date = date.minusDays(1)) {
+            if(!answerExistMap.get(date)) {
+                if(date.equals(now)) continue;
+                break;
+            }
+            realCount++;
+        }
+
+        // when
+        int calculateCount = AnalyticsUtil.calculateConsecutiveDaysCount(answerResDtoList, startDate, endDate);
+
+        // then
+        assertEquals(realCount, calculateCount);
+
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#149 

## 📝작업 내용

### 📄 AnalyticsUti.java
- 연속 N일차 달성 값 계산 메소드
- 정책
  - 오늘 리허설 미진행, 1일전 2일전 리허설 진행한 경우 2일차
  - 오늘 리허설 진행, 1일전 2일전 리허설 진행한 경우 3일차
  - 오늘 리허설 진행, 1일전 리허설 진행하지 않은 경우 1일차
```java
public static int calculateConsecutiveDaysCount(List<AnswerResDto> answers, LocalDate startDate, LocalDate endDate) {

    LocalDate today = LocalDate.now();

    // 오늘 리허설을 진행했다면, 1 추가
    int consecutiveDays = answers.stream()
            .anyMatch(dto -> dto.answerDate().isEqual(today) && dto.isExisted()) ? 1 : 0;

    consecutiveDays += Math.toIntExact(
            answers.stream()
                    .filter(dto -> {
                        LocalDate date = dto.answerDate();
                        return !date.isBefore(startDate) && !date.isAfter(today.minusDays(1));
                    })
                    .sorted(Comparator.comparing(AnswerResDto::answerDate).reversed())
                    .map(AnswerResDto::isExisted)
                    .takeWhile(Boolean.TRUE::equals)
                    .count()
    );

    return consecutiveDays;
}
```

### 📄 AnswerService.java
- 미나리 달성률 -> 연속 N일차 달성 값으로 변경
```java
public AnswerHistoryResDto getAnswerHistoryList(LocalDate startDate, LocalDate endDate, User user) {

        // 미나리 N일 연속
        int consecutiveDays = AnalyticsUtil.calculateConsecutiveDaysCount(answerResList, startDate, endDate);

        return AnswerHistoryResDto.create(consecutiveDays, answerResList);
}
```

### 📄 AnalyticsUtilTest.java
- 랜덤으로 데이터를 생성하여 매번 일치하는지 확인하는 테스트 코드 작성
```java
@Test
void calculateConsecutiveDaysCount() {

    // given
    LocalDate now = LocalDate.now();
    LocalDate startDate = now.minusDays(15);
    LocalDate endDate = now.plusDays(15);

    List<AnswerResDto> answerResDtoList = Stream
            .iterate(startDate, date -> !date.isAfter(endDate), date -> date.plusDays(1))
            .map(date -> new AnswerResDto(random.nextBoolean(), 0L, date, 0L))
            .toList();

    Map<LocalDate, Boolean> answerExistMap = answerResDtoList.stream()
            .collect(Collectors.toMap(
                    AnswerResDto::answerDate,
                    AnswerResDto::isExisted
            ));

    int realCount = 0;
    for(LocalDate date = now; !date.isBefore(startDate); date = date.minusDays(1)) {
        if(!answerExistMap.get(date)) {
            if(date.equals(now)) continue;
            break;
        }
        realCount++;
    }

    // when
    int calculateCount = AnalyticsUtil.calculateConsecutiveDaysCount(answerResDtoList, startDate, endDate);

    // then
    assertEquals(realCount, calculateCount);

}
```


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a display of consecutive days with answers in the answer history, replacing the previous achievement rate metric.

* **Tests**
  * Introduced new tests to ensure accurate calculation of consecutive answer days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->