### PR TITLE
[Feat(#168)] pg요청을 위해 사용자 id를 64길이의 문자열로 변환하는 util 개발

### DIFF
--- a/src/main/java/com/prography/minari/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/prography/minari/answer/repository/AnswerRepository.java
@@ -28,7 +28,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     List<Answer> findByUserIdAndAnsweredDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 
     @Query("SELECT COUNT(DISTINCT a.answeredDate) FROM Answer a WHERE a.user.id = :userId")
-    Long countDistinctAnswerDateByUserId(Long userId);
+    Long countDistinctAnswerDateByUserId(@Param("userId") Long userId);
 
     long countByUserIdAndQuestionId(Long userId, Long questionId);
 

--- a/src/main/java/com/prography/minari/common/util/uuid/UuidCreateUtil.java
+++ b/src/main/java/com/prography/minari/common/util/uuid/UuidCreateUtil.java
@@ -1,0 +1,37 @@
+package com.prography.minari.common.util.uuid;
+
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class UuidCreateUtil {
+    private static final char[] ALLOWED =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".toCharArray();
+    private static final int FIXED_LEN = 64;
+
+    public static String createTossUUIDKeyLongToString(long value) {
+        try {
+            // 1. long -> byte[]
+            byte[] inputBytes = ByteBuffer.allocate(Long.BYTES).putLong(value).array();
+
+            // 2. SHA-256 해시
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(inputBytes);
+
+            // 3. 해시 바이트를 허용 문자 집합으로 변환
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hash) {
+                int unsigned = b & 0xFF;
+                sb.append(ALLOWED[unsigned % ALLOWED.length]);
+            }
+
+            // 4. 64자 만들기 (32바이트 해시 -> 32문자이므로, 2번 반복)
+            while (sb.length() < FIXED_LEN) {
+                sb.append(sb);
+            }
+            return sb.substring(0, FIXED_LEN);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/prography/minari/user/dto/UserFindResDto.java
+++ b/src/main/java/com/prography/minari/user/dto/UserFindResDto.java
@@ -1,7 +1,6 @@
 package com.prography.minari.user.dto;
 
 import com.prography.minari.common.entity.Domain;
-import com.prography.minari.payment.entity.Seed;
 import com.prography.minari.social.dto.enums.SocialType;
 import com.prography.minari.user.entity.User;
 import com.prography.minari.user.enums.UserRole;
@@ -17,10 +16,11 @@ public record UserFindResDto(
         String uuid,
         Domain domain,
         UserRole userRole,
-        Long dayCount
+        Long dayCount,
+        String customerKeyForPG
 )
 {
-    public static UserFindResDto from(User user, Long seed, Long dayCount) {
+    public static UserFindResDto from(User user, Long seed, Long dayCount,String customerKeyForToss) {
         return new UserFindResDto(
                 user.getId(),
                 user.getEmail(),
@@ -32,7 +32,8 @@ public record UserFindResDto(
                 user.getUuid(),
                 user.getDomain(),
                 user.getUserRole(),
-                dayCount
+                dayCount,
+                customerKeyForToss
         );
     }
 }

--- a/src/main/java/com/prography/minari/user/service/UserService.java
+++ b/src/main/java/com/prography/minari/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.prography.minari.common.execption.ApiException;
 import com.prography.minari.common.execption.ErrorCode;
 import com.prography.minari.common.service.impl.RedisProcessor;
 import com.prography.minari.common.util.JwtUtil;
+import com.prography.minari.common.util.uuid.UuidCreateUtil;
 import com.prography.minari.payment.entity.Seed;
 import com.prography.minari.payment.service.impl.CreditCounter;
 import com.prography.minari.payment.service.impl.SeedReader;
@@ -37,7 +38,8 @@ public class UserService {
         User user = userReader.read(id);
         Long creditTotal = creditCounter.countNotUsedCredit(id);
         Long dayCount = answerReader.countDistinctAnswerDateByUserId(id);
-        return UserFindResDto.from(user, creditTotal, dayCount);
+        String tossUUIDKeyLongToString = UuidCreateUtil.createTossUUIDKeyLongToString(user.getId());
+        return UserFindResDto.from(user, creditTotal, dayCount,tossUUIDKeyLongToString);
     }
 
     public UserJoinResDto join(UserJoinReqDto userJoinReqDto, Long userId) {

--- a/src/test/java/com/prography/minari/common/util/uuid/UuidCreateUtilTest.java
+++ b/src/test/java/com/prography/minari/common/util/uuid/UuidCreateUtilTest.java
@@ -1,0 +1,49 @@
+package com.prography.minari.common.util.uuid;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import static com.prography.minari.common.util.uuid.UuidCreateUtil.createTossUUIDKeyLongToString;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UuidCreateUtilTest {
+    private static final String ALLOWED_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+    @RepeatedTest(10)
+    void sameInputShouldReturnSameOutput() {
+        long value = 123456789L;
+        String first = createTossUUIDKeyLongToString(value);
+        String second = createTossUUIDKeyLongToString(value);
+        System.out.println(first);
+        assertEquals(first, second, "같은 값은 같은 문자열을 반환해야 합니다.");
+    }
+
+    @Test
+    void differentInputShouldReturnDifferentOutput() {
+        long value1 = 123456789L;
+        long value2 = 987654321L;
+        String first = createTossUUIDKeyLongToString(value1);
+        String second = createTossUUIDKeyLongToString(value2);
+
+        assertNotEquals(first, second, "다른 값은 다른 문자열을 반환해야 합니다.");
+    }
+
+    @Test
+    void outputShouldBe64CharactersLong() {
+        long value = 42L;
+        String output = createTossUUIDKeyLongToString(value);
+
+        assertEquals(64, output.length(), "출력 문자열 길이는 항상 64자여야 합니다.");
+    }
+
+    @Test
+    void outputShouldContainOnlyAllowedCharacters() {
+        long value = 123456789L;
+        String output = createTossUUIDKeyLongToString(value);
+
+        for (char c : output.toCharArray()) {
+            assertTrue(ALLOWED_CHARS.indexOf(c) >= 0,
+                    "허용되지 않은 문자가 포함되어 있습니다: " + c);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#168 #163 

## 📝작업 내용
### PG요청시 아래와 같은 제한사항존재
<img width="1576" height="126" alt="image (1)" src="https://github.com/user-attachments/assets/e3ed2298-6dd0-4629-b3e9-7b9fc1c84894" />

### UuidCreateUtil

**유일성을 보장하기 위해 SHA-256 해시함수로 변환**
```
MessageDigest md = MessageDigest.getInstance("SHA-256");
byte[] hash = md.digest(inputBytes);
```

**정해진 규칙에 맞게 변환**
```
for (byte b : hash) {
    int unsigned = b & 0xFF;
    sb.append(ALLOWED[unsigned % ALLOWED.length]);
}
```


**기존 **사용자 조회** API의 응답값에 문자열 추가**


## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a utility for generating fixed-length UUID-like keys from numeric values.
  * User details now include a new customer key field for payment gateway integration.

* **Bug Fixes**
  * Improved parameter handling in answer count queries for better reliability.

* **Tests**
  * Introduced tests to ensure the consistency and validity of the UUID key generation utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->